### PR TITLE
VD: supernova fcl in the small geo

### DIFF
--- a/fcl/dunefdvd/g4/supernova_g4_dunevd10kt_1x8x6_3view.fcl
+++ b/fcl/dunefdvd/g4/supernova_g4_dunevd10kt_1x8x6_3view.fcl
@@ -1,0 +1,5 @@
+#include "standard_g4_dunevd10kt_1x8x6_3view.fcl"
+
+process_name: SupernovaG4
+
+services.PhysicsList:   @local::dune_physics_list_supernova


### PR DESCRIPTION
Including a new fhicl file in the 1x8x6 geometry for low energy events.