### PR TITLE
Add reco fcl for DUNE FD atmospheric samples

### DIFF
--- a/fcl/dunefd/reco/standard_reco_atmos_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/reco/standard_reco_atmos_dune10kt_1x2x6.fcl
@@ -1,0 +1,4 @@
+#include "standard_reco_dune10kt_1x2x6.fcl"
+
+physics.producers.pandora.ConfigFile:   "PandoraSettings_Master_Atmos_DUNEFD.xml"
+


### PR DESCRIPTION
This pull request follows on from the dunereco [PR 7](https://github.com/DUNE/dunereco/pull/7) to add a fcl targeting atmospheric samples using Pandora's new vertex selection BDT.