### PR TITLE
adding LE gen for VD 1x8x6 geo

### DIFF
--- a/fcl/dunefdvd/gen/background/prodbackground_radiological_decay0_dunevd10kt_1x8x6.fcl
+++ b/fcl/dunefdvd/gen/background/prodbackground_radiological_decay0_dunevd10kt_1x8x6.fcl
@@ -1,0 +1,88 @@
+#include "services_dune.fcl"
+#include "dune_radiological_model_decay0_vd_1x8x6.fcl"
+
+process_name: MARLEYGen
+
+services:
+{
+   @table::dunefd_services
+   TFileService:          { fileName: "prodradiological_hist.root" }
+   TimeTracker:           {}
+   RandomNumberGenerator: {}                 # ART native random number generator
+   FileCatalogMetadata:  @local::art_file_catalog_mc
+   message:              @local::dune_message_services_prod
+}
+
+source:
+{
+   module_type: EmptyEvent
+   timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+   maxEvents:   10          # Number of events to create
+   firstRun:    20000047    # Run number to use for this file
+   firstEvent:  1           # number of first event in the file
+}
+
+physics:
+
+{
+   producers:
+   {
+      ##########################################################################
+      # Liquid Argon
+      Ar39GenInLAr:		@local::dune10kt_39Ar_in_LAr
+      Kr85GenInLAr:             @local::dune10kt_85Kr_in_LAr
+      Ar42GenInLAr:             @local::dune10kt_42Ar_in_LAr
+      K42From42ArGenInLAr:	@local::dune10kt_42Kfrom42Ar_in_LAr
+      Rn222ChainGenInLAr:	@local::dune10kt_222Rn_chain_in_LAr
+      ##########################################################################
+
+      ##########################################################################
+      # Cathode
+      K42From42ArGenInCPA:	@local::dune10kt_42Kfrom42Ar_in_CPA
+      K40inGenInCPA:	 	@local::dune10kt_40K_in_CPA
+      U238ChainGenInCPA: 	@local::dune10kt_238U_chain_in_CPA
+      ##########################################################################
+
+      ##########################################################################
+      # CRP
+      Co60inGenInAPA:	 	@local::dune10kt_60Co_in_APA
+      U238ChainGenInAPA: 	@local::dune10kt_238U_chain_in_APA
+      ##########################################################################
+
+      ##########################################################################
+      # PDS
+      Rn222ChainGenInPDS: 	@local::dune10kt_222Rn_chain_in_PDS
+      ##########################################################################
+
+      ##########################################################################
+      # Externals
+      NeutronGenInRock:    	@local::dune10kt_neutron_from_rock
+      GammasGenInRock:          @local::dune10kt_caverngammas
+      ##########################################################################
+
+      rns:       { module_type: "RandomNumberSaver" }
+   }
+
+   simulate: [rns, Ar39GenInLAr, Kr85GenInLAr, Ar42GenInLAr, K42From42ArGenInLAr, Rn222ChainGenInLAr, K42From42ArGenInCPA, K40inGenInCPA, U238ChainGenInCPA, Co60inGenInAPA, U238ChainGenInAPA, Rn222ChainGenInPDS, NeutronGenInRock, GammasGenInRock]
+   stream1:       [ out1 ]
+   trigger_paths: [ simulate ] 
+   end_paths:     [ stream1 ]  
+}
+
+outputs:
+{
+   out1:
+   {
+      module_type: RootOutput
+      fileName:    "prodradiological_decay0_dunevd10kt_1x8x6_gen.root" # Default file name, can override from command line with -o or --output
+      dataTier:    "generated"
+      compressionLevel: 1
+   }
+}
+
+services:
+{
+    @table::services
+    @table::dunefdvd_1x8x6_3view_30deg_simulation_services
+}
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v4_geo

--- a/fcl/dunefdvd/gen/ndk/prodndk_radiological_decay0_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/gen/ndk/prodndk_radiological_decay0_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -1,0 +1,94 @@
+#include "services_dune.fcl"
+#include "genie_dune.fcl"
+#include "dune_radiological_model_decay0_vd_1x8x6.fcl"
+
+process_name: GenieNDK
+
+services:
+{
+   @table::dunefd_services
+   TFileService:          { fileName: "prodradiological_hist.root" }
+   TimeTracker:           {}
+   RandomNumberGenerator: {}                 # ART native random number generator
+   FileCatalogMetadata:  @local::art_file_catalog_mc
+   message:              @local::dune_message_services_prod
+}
+
+source:
+{
+   module_type: EmptyEvent
+   timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+   maxEvents:   10          # Number of events to create
+   firstRun:    20000047    # Run number to use for this file
+   firstEvent:  1           # number of first event in the file
+}
+
+physics:
+
+{
+   producers:
+   {
+      ##########################################################################
+      # NDK Signal
+      NDKgen:			@local::standard_ndk
+      ##########################################################################
+
+      ##########################################################################
+      # Liquid Argon
+      Ar39GenInLAr:		@local::dune10kt_39Ar_in_LAr
+      Kr85GenInLAr:             @local::dune10kt_85Kr_in_LAr
+      Ar42GenInLAr:             @local::dune10kt_42Ar_in_LAr
+      K42From42ArGenInLAr:	@local::dune10kt_42Kfrom42Ar_in_LAr
+      Rn222ChainGenInLAr:	@local::dune10kt_222Rn_chain_in_LAr
+      ##########################################################################
+
+      ##########################################################################
+      # Cathode
+      K42From42ArGenInCPA:	@local::dune10kt_42Kfrom42Ar_in_CPA
+      K40inGenInCPA:	 	@local::dune10kt_40K_in_CPA
+      U238ChainGenInCPA: 	@local::dune10kt_238U_chain_in_CPA
+      ##########################################################################
+
+      ##########################################################################
+      # CRP
+      Co60inGenInAPA:	 	@local::dune10kt_60Co_in_APA
+      U238ChainGenInAPA: 	@local::dune10kt_238U_chain_in_APA
+      ##########################################################################
+
+      ##########################################################################
+      # PDS
+      Rn222ChainGenInPDS: 	@local::dune10kt_222Rn_chain_in_PDS
+      ##########################################################################
+
+      ##########################################################################
+      # Externals
+      NeutronGenInRock:    	@local::dune10kt_neutron_from_rock
+      GammasGenInRock:          @local::dune10kt_caverngammas
+      ##########################################################################
+
+      rns:       { module_type: "RandomNumberSaver" }
+   }
+
+   simulate: [rns, NDKgen, Ar39GenInLAr, Kr85GenInLAr, Ar42GenInLAr, K42From42ArGenInLAr, Rn222ChainGenInLAr, K42From42ArGenInCPA, K40inGenInCPA, U238ChainGenInCPA, Co60inGenInAPA, U238ChainGenInAPA, Rn222ChainGenInPDS, NeutronGenInRock, GammasGenInRock]
+   stream1:       [ out1 ]
+   trigger_paths: [ simulate ] 
+   end_paths:     [ stream1 ]  
+}
+
+outputs:
+{
+   out1:
+   {
+      module_type: RootOutput
+      fileName:    "prodradiological_decay0_dunevd10kt_1x8x6_gen.root" # Default file name, can override from command line with -o or --output
+      dataTier:    "generated"
+      compressionLevel: 1
+   }
+}
+
+services:
+{
+    @table::services
+    @table::dunefdvd_1x8x6_3view_30deg_simulation_services
+}
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v4_geo

--- a/fcl/dunefdvd/gen/supernova/prodmarley_nue_spectrum_radiological_decay0_hudepohl_11.2M_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/gen/supernova/prodmarley_nue_spectrum_radiological_decay0_hudepohl_11.2M_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -1,0 +1,93 @@
+#include "services_dune.fcl"
+#include "marley_dune.fcl"
+#include "dune_radiological_model_decay0_vd_1x8x6.fcl"
+
+process_name: MARLEYGen
+
+services:
+{
+   @table::dunefd_services
+   TFileService:          { fileName: "prodmarley_radiological_decay0_integrated-hudepohl-shen-cooling-s11.2co_hist.root" }
+   TimeTracker:           {}
+   RandomNumberGenerator: {}                 # ART native random number generator
+   FileCatalogMetadata:  @local::art_file_catalog_mc
+   message:              @local::dune_message_services_prod
+}
+
+source:
+{
+   module_type: EmptyEvent
+   timestampPlugin: { plugin_type: "GeneratedEventTimestamp" }
+   maxEvents:   10          # Number of events to create
+   firstRun:    20000047    # Run number to use for this file
+   firstEvent:  1           # number of first event in the file
+}
+
+physics:
+{
+   producers:
+   {
+      ##########################################################################
+      # MARLEY
+      marley:      @local::dune_marley_nue_spectrum
+      ##########################################################################
+
+      ##########################################################################
+      # Liquid Argon
+      Ar39GenInLAr:		@local::dune10kt_39Ar_in_LAr
+      Kr85GenInLAr:             @local::dune10kt_85Kr_in_LAr
+      Ar42GenInLAr:             @local::dune10kt_42Ar_in_LAr
+      K42From42ArGenInLAr:	@local::dune10kt_42Kfrom42Ar_in_LAr
+      Rn222ChainGenInLAr:	@local::dune10kt_222Rn_chain_in_LAr
+      ##########################################################################
+
+      ##########################################################################
+      # Cathode
+      K42From42ArGenInCPA:	@local::dune10kt_42Kfrom42Ar_in_CPA
+      K40inGenInCPA:	 	@local::dune10kt_40K_in_CPA
+      U238ChainGenInCPA: 	@local::dune10kt_238U_chain_in_CPA
+      ##########################################################################
+
+      ##########################################################################
+      # CRP
+      Co60inGenInAPA:	 	@local::dune10kt_60Co_in_APA
+      U238ChainGenInAPA: 	@local::dune10kt_238U_chain_in_APA
+      ##########################################################################
+
+      ##########################################################################
+      # PDS
+      Rn222ChainGenInPDS: 	@local::dune10kt_222Rn_chain_in_PDS
+      ##########################################################################
+
+      ##########################################################################
+      # Externals
+      NeutronGenInRock:    	@local::dune10kt_neutron_from_rock
+      GammasGenInRock:          @local::dune10kt_caverngammas
+      ##########################################################################
+
+      rns:       { module_type: "RandomNumberSaver" }
+   }
+
+   simulate: [rns, marley, Ar39GenInLAr, Kr85GenInLAr, Ar42GenInLAr, K42From42ArGenInLAr, Rn222ChainGenInLAr, K42From42ArGenInCPA, K40inGenInCPA, U238ChainGenInCPA, Co60inGenInAPA, U238ChainGenInAPA, Rn222ChainGenInPDS, NeutronGenInRock, GammasGenInRock]
+   stream1:       [ out1 ]
+   trigger_paths: [ simulate ] 
+   end_paths:     [ stream1 ]  
+}
+
+outputs:
+{
+   out1:
+   {
+      module_type: RootOutput
+      fileName:    "prodmarley_radiological_integrated-hudepohl-shen-cooling-s11.2co_dunevd10kt_1x8x6_gen.root" # Default file name, can override from command line with -o or --output
+      dataTier:    "generated"
+      compressionLevel: 1
+   }
+}
+
+services:
+{
+    @table::services
+    @table::dunefdvd_1x8x6_3view_30deg_simulation_services
+}
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v4_geo


### PR DESCRIPTION
New fhicl files for the VD's TDR production of LE events. These are for the v4 of the 1x8x6 geometry, which contains an anode plate for radiological generation.