### PR TITLE
Use the dedicated VD neutrino energy reco tunings for 30deg.

### DIFF
--- a/fcl/dunefdvd/reco/standard_reco_dunevd10kt_1x8x14_3view_30deg.fcl
+++ b/fcl/dunefdvd/reco/standard_reco_dunevd10kt_1x8x14_3view_30deg.fcl
@@ -7,3 +7,6 @@ services: {
 
 physics.reco: [ @sequence::dunefd_vertdrift_reco_all_systems ]
 
+physics.producers.energyrecnumu:     @local::dunefdvd_30deg_nuenergyreco_pandora_numu
+physics.producers.energyrecnue:      @local::dunefdvd_30deg_nuenergyreco_pandora_nue
+physics.producers.energyrecnc:       @local::dunefdvd_30deg_nuenergyreco_pandora_nc

--- a/fcl/dunefdvd/reco/standard_reco_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/reco/standard_reco_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -7,3 +7,7 @@ services: {
 
 physics.reco: [ @sequence::dunefd_vertdrift_reco_all_systems ]
 
+physics.producers.energyrecnumu:     @local::dunefdvd_30deg_nuenergyreco_pandora_numu
+physics.producers.energyrecnue:      @local::dunefdvd_30deg_nuenergyreco_pandora_nue
+physics.producers.energyrecnc:       @local::dunefdvd_30deg_nuenergyreco_pandora_nc
+


### PR DESCRIPTION
Update the 30deg VD reco to use the dedicated neutrino energy tunings.

Pulls information from dunereco PR: https://github.com/DUNE/dunereco/pull/25