### PR TITLE
The necessary changes alongside with the hybrid model for the fast light sim

### DIFF
--- a/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view.fcl
+++ b/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view.fcl
@@ -16,3 +16,21 @@ physics:
 
     simulate: [ @sequence::dunefd_vertdrift_detsim_all_systems ]
 }
+
+# New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
+physics.producers.sipm10ppmExt: @erase
+physics.producers.opdigi10ppm.InputTags: [sipmAr10ppm, sipmXe10ppm]
+
+dunefd_vertdrift_pds_bothelements_new:
+[
+    sipmAr10ppm,
+    sipmXe10ppm,
+    opdigi10ppm
+]
+dunefd_vertdrift_detsim_all_systems_new:
+[
+    rns,
+    @sequence::dunefd_vertdrift_tpc,
+    @sequence::dunefd_vertdrift_pds_bothelements_new
+]
+physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_new ]

--- a/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view.fcl
+++ b/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view.fcl
@@ -14,10 +14,9 @@ physics:
       tpcrawdecoder: @local::dune10kt_dunefd_vertdrift_1x8x6_3view_sim_nfsp
     }
 
-    simulate: [ @sequence::dunefd_vertdrift_detsim_all_systems ]
+    simulate: [ @sequence::dunefd_vertdrift_detsim_all_systems_1x8x6 ]
 }
 
 # New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
 physics.producers.sipm10ppmExt: @erase
 physics.producers.opdigi10ppm.InputTags: [sipmAr10ppm, sipmXe10ppm]
-physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_1x8x6 ]

--- a/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view.fcl
+++ b/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view.fcl
@@ -20,17 +20,4 @@ physics:
 # New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
 physics.producers.sipm10ppmExt: @erase
 physics.producers.opdigi10ppm.InputTags: [sipmAr10ppm, sipmXe10ppm]
-
-dunefd_vertdrift_pds_bothelements_new:
-[
-    sipmAr10ppm,
-    sipmXe10ppm,
-    opdigi10ppm
-]
-dunefd_vertdrift_detsim_all_systems_new:
-[
-    rns,
-    @sequence::dunefd_vertdrift_tpc,
-    @sequence::dunefd_vertdrift_pds_bothelements_new
-]
-physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_new ]
+physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_1x8x6 ]

--- a/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -16,3 +16,21 @@ physics:
 
     simulate: [ @sequence::dunefd_vertdrift_detsim_all_systems ]
 }
+
+# New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
+physics.producers.sipm10ppmExt: @erase
+physics.producers.opdigi10ppm.InputTags: [sipmAr10ppm, sipmXe10ppm]
+
+dunefd_vertdrift_pds_bothelements_new:
+[
+    sipmAr10ppm,
+    sipmXe10ppm,
+    opdigi10ppm
+]
+dunefd_vertdrift_detsim_all_systems_new:
+[
+    rns,
+    @sequence::dunefd_vertdrift_tpc,
+    @sequence::dunefd_vertdrift_pds_bothelements_new
+]
+physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_new ]

--- a/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -14,10 +14,9 @@ physics:
       tpcrawdecoder: @local::dune10kt_dunefd_vertdrift_1x8x6_3view_30deg_sim_nfsp
     }
 
-    simulate: [ @sequence::dunefd_vertdrift_detsim_all_systems ]
+    simulate: [ @sequence::dunefd_vertdrift_detsim_all_systems_1x8x6 ]
 }
 
 # New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
 physics.producers.sipm10ppmExt: @erase
 physics.producers.opdigi10ppm.InputTags: [sipmAr10ppm, sipmXe10ppm]
-physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_1x8x6 ]

--- a/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/detsim/standard_detsim_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -20,17 +20,4 @@ physics:
 # New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
 physics.producers.sipm10ppmExt: @erase
 physics.producers.opdigi10ppm.InputTags: [sipmAr10ppm, sipmXe10ppm]
-
-dunefd_vertdrift_pds_bothelements_new:
-[
-    sipmAr10ppm,
-    sipmXe10ppm,
-    opdigi10ppm
-]
-dunefd_vertdrift_detsim_all_systems_new:
-[
-    rns,
-    @sequence::dunefd_vertdrift_tpc,
-    @sequence::dunefd_vertdrift_pds_bothelements_new
-]
-physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_new ]
+physics.simulate:[ @sequence::dunefd_vertdrift_detsim_all_systems_1x8x6 ]

--- a/fcl/dunefdvd/detsim/workflow_detsim_dunevd10kt.fcl
+++ b/fcl/dunefdvd/detsim/workflow_detsim_dunevd10kt.fcl
@@ -54,7 +54,12 @@ dunefd_vertdrift_pds_bothelements:
     sipm10ppmExt,
     opdigi10ppm
 ]
-
+dunefd_vertdrift_pds_bothelements_1x8x6:
+[
+    sipmAr10ppm,
+    sipmXe10ppm,
+    opdigi10ppm
+]
 dunefd_vertdrift_detsim_pds_only:
 [
     rns,
@@ -72,6 +77,13 @@ dunefd_vertdrift_detsim_all_systems:
     rns,
     @sequence::dunefd_vertdrift_tpc,
     @sequence::dunefd_vertdrift_pds_bothelements
+]
+
+dunefd_vertdrift_detsim_all_systems_1x8x6:
+[
+    rns,
+    @sequence::dunefd_vertdrift_tpc,
+    @sequence::dunefd_vertdrift_pds_bothelements_1x8x6
 ]
 
 #Overrides

--- a/fcl/dunefdvd/detsim/workflow_detsim_dunevd10kt.fcl
+++ b/fcl/dunefdvd/detsim/workflow_detsim_dunevd10kt.fcl
@@ -17,15 +17,15 @@ dunefd_vertdrift_producers:
    tpcrawdecoder: @local::tpcrawdecoder_dunefd_vertdrift_2view
    # for light signal 
    sipmArOnly:    @local::xarapuca_ar              #TPC Active volume
-   sipmArOnlyExt: @local::xarapuca_ar              #Region between FC and Cryostat wall
+   # sipmArOnlyExt: @local::xarapuca_ar            #Region between FC and Cryostat wall
    sipmXeOnly:    @local::xarapuca_xetuned_xe10ppm
-   sipmXeOnlyExt: @local::xarapuca_xetuned_xe10ppm
+   # sipmXeOnlyExt: @local::xarapuca_xetuned_xe10ppm
    sipmAr10ppm:   @local::xarapuca_ar_xe10ppm
    sipmAr10ppmExt:@local::xarapuca_ar_xe10ppm
    sipmXe10ppm:   @local::xarapuca_xe_xe10ppm
    sipmXe10ppmExt:@local::xarapuca_xe_xe10ppm
-   opdigiArOnly:  @local::standard_daphne
-   opdigiXeOnly:  @local::standard_daphne
+   # opdigiArOnly:  @local::standard_daphne
+   # opdigiXeOnly:  @local::standard_daphne
    opdigi10ppm:   @local::standard_daphne
 }
 
@@ -37,15 +37,15 @@ dunefd_vertdrift_tpc:
 dunefd_vertdrift_pds_aronly:
 [
     sipmArOnly,
-    sipmArOnlyExt,
-    opdigiArOnly
+    # sipmArOnlyExt,
+    # opdigiArOnly
 ]
 
 dunefd_vertdrift_pds_xeonly:
 [
     sipmXeOnly,
-    sipmXeOnlyExt,
-    opdigiXeOnly
+    # sipmXeOnlyExt,
+    # opdigiXeOnly
 ]
 
 dunefd_vertdrift_pds_bothelements:
@@ -78,14 +78,14 @@ dunefd_vertdrift_detsim_all_systems:
 
 #Overrides
 dunefd_vertdrift_producers.sipmArOnly.InputTag:     "PDFastSimAr"
-dunefd_vertdrift_producers.sipmArOnlyExt.InputTag:  "PDFastSimArExternal"
+# dunefd_vertdrift_producers.sipmArOnlyExt.InputTag:  "PDFastSimArExternal"
 dunefd_vertdrift_producers.sipmXeOnly.InputTag:     "PDFastSimXe" #Default, but set anyway for clarity
-dunefd_vertdrift_producers.sipmXeOnlyExt.InputTag:  "PDFastSimXeExternal" 
+# dunefd_vertdrift_producers.sipmXeOnlyExt.InputTag:  "PDFastSimXeExternal" 
 dunefd_vertdrift_producers.sipmAr10ppm.InputTag:    "PDFastSimAr"
-dunefd_vertdrift_producers.sipmAr10ppmExt.InputTag: "PDFastSimArExternal"
+dunefd_vertdrift_producers.sipmAr10ppmExt.InputTag: "PDFastSimExternal" # This is a merged version between argon and xenon, need to be upgraded in the future. 
 dunefd_vertdrift_producers.sipmXe10ppm.InputTag:    "PDFastSimXe" #Default, but set anyway for clarity
-dunefd_vertdrift_producers.opdigiArOnly.InputTags:   [sipmArOnly, sipmArOnlyExt]
-dunefd_vertdrift_producers.opdigiXeOnly.InputTags:   [sipmXeOnly, sipmXeOnlyExt]
+# dunefd_vertdrift_producers.opdigiArOnly.InputTags:   [sipmArOnly, sipmArOnlyExt]
+# dunefd_vertdrift_producers.opdigiXeOnly.InputTags:   [sipmXeOnly, sipmXeOnlyExt]
 dunefd_vertdrift_producers.opdigi10ppm.InputTags:    [sipmAr10ppm, sipmAr10ppmExt, sipmXe10ppm, sipmXe10ppmExt]
 
 END_PROLOG

--- a/fcl/dunefdvd/detsim/workflow_detsim_dunevd10kt.fcl
+++ b/fcl/dunefdvd/detsim/workflow_detsim_dunevd10kt.fcl
@@ -17,16 +17,15 @@ dunefd_vertdrift_producers:
    tpcrawdecoder: @local::tpcrawdecoder_dunefd_vertdrift_2view
    # for light signal 
    sipmArOnly:    @local::xarapuca_ar              #TPC Active volume
-   # sipmArOnlyExt: @local::xarapuca_ar            #Region between FC and Cryostat wall
+   sipmArOnlyExt: @local::xarapuca_ar              #Region between FC and Cryostat wall
    sipmXeOnly:    @local::xarapuca_xetuned_xe10ppm
-   # sipmXeOnlyExt: @local::xarapuca_xetuned_xe10ppm
+   sipmXeOnlyExt: @local::xarapuca_xetuned_xe10ppm
    sipmAr10ppm:   @local::xarapuca_ar_xe10ppm
-   sipmAr10ppmExt:@local::xarapuca_ar_xe10ppm
    sipmXe10ppm:   @local::xarapuca_xe_xe10ppm
-   sipmXe10ppmExt:@local::xarapuca_xe_xe10ppm
-   # opdigiArOnly:  @local::standard_daphne
-   # opdigiXeOnly:  @local::standard_daphne
-   opdigi10ppm:   @local::standard_daphne
+   sipm10ppmExt:  @local::xarapuca_ar              #Merged library for Ar and Xe mix already in place. No extra cuts
+   opdigiArOnly:  @local::standard_vddaphne
+   opdigiXeOnly:  @local::standard_vddaphne
+   opdigi10ppm:   @local::standard_vddaphne
 }
 
 dunefd_vertdrift_tpc:
@@ -37,23 +36,22 @@ dunefd_vertdrift_tpc:
 dunefd_vertdrift_pds_aronly:
 [
     sipmArOnly,
-    # sipmArOnlyExt,
-    # opdigiArOnly
+    sipmArOnlyExt,
+    opdigiArOnly
 ]
 
 dunefd_vertdrift_pds_xeonly:
 [
     sipmXeOnly,
-    # sipmXeOnlyExt,
-    # opdigiXeOnly
+    sipmXeOnlyExt,
+    opdigiXeOnly
 ]
 
 dunefd_vertdrift_pds_bothelements:
 [
     sipmAr10ppm,
-    sipmAr10ppmExt,
     sipmXe10ppm,
-    sipmXe10ppmExt,
+    sipm10ppmExt,
     opdigi10ppm
 ]
 
@@ -78,14 +76,14 @@ dunefd_vertdrift_detsim_all_systems:
 
 #Overrides
 dunefd_vertdrift_producers.sipmArOnly.InputTag:     "PDFastSimAr"
-# dunefd_vertdrift_producers.sipmArOnlyExt.InputTag:  "PDFastSimArExternal"
+dunefd_vertdrift_producers.sipmArOnlyExt.InputTag:  "PDFastSimExternal"
 dunefd_vertdrift_producers.sipmXeOnly.InputTag:     "PDFastSimXe" #Default, but set anyway for clarity
-# dunefd_vertdrift_producers.sipmXeOnlyExt.InputTag:  "PDFastSimXeExternal" 
+dunefd_vertdrift_producers.sipmXeOnlyExt.InputTag:  "PDFastSimExternal" 
 dunefd_vertdrift_producers.sipmAr10ppm.InputTag:    "PDFastSimAr"
-dunefd_vertdrift_producers.sipmAr10ppmExt.InputTag: "PDFastSimExternal" # This is a merged version between argon and xenon, need to be upgraded in the future. 
 dunefd_vertdrift_producers.sipmXe10ppm.InputTag:    "PDFastSimXe" #Default, but set anyway for clarity
-# dunefd_vertdrift_producers.opdigiArOnly.InputTags:   [sipmArOnly, sipmArOnlyExt]
-# dunefd_vertdrift_producers.opdigiXeOnly.InputTags:   [sipmXeOnly, sipmXeOnlyExt]
-dunefd_vertdrift_producers.opdigi10ppm.InputTags:    [sipmAr10ppm, sipmAr10ppmExt, sipmXe10ppm, sipmXe10ppmExt]
+dunefd_vertdrift_producers.sipm10ppmExt.InputTag:   "PDFastSimExternal" 
+dunefd_vertdrift_producers.opdigiArOnly.InputTags:   [sipmArOnly, sipmArOnlyExt]
+dunefd_vertdrift_producers.opdigiXeOnly.InputTags:   [sipmXeOnly, sipmXeOnlyExt]
+dunefd_vertdrift_producers.opdigi10ppm.InputTags:    [sipmAr10ppm, sipmXe10ppm, sipm10ppmExt]
 
 END_PROLOG

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
@@ -38,9 +38,9 @@ physics:
      IonAndScintExternal: @local::dunefdvd_ionandscint_external
      elecDrift:   @local::dunefd_elecdrift
      PDFastSimAr: @local::dunevd_pdfastsim_par_ar_fastonly
-     PDFastSimArExternal: @local::dunevd_pdfastsim_par_ar_external_fastonly
+     PDFastSimArExternal: @local::dunevd_pdfastsim_pvs_external
      PDFastSimXe: @local::dunevd_pdfastsim_par_xe
-     PDFastSimXeExternal: @local::dunevd_pdfastsim_par_xe_external
+     PDFastSimXeExternal: @local::dunevd_pdfastsim_pvs_external
      rns:         { module_type: "RandomNumberSaver" }
   }
 

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
@@ -16,8 +16,6 @@ services:
   FileCatalogMetadata:   @local::art_file_catalog_mc
 
   @table::dunefdvd_simulation_services
-  PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe 
-  # The PhotonVisibilityService is used for the hybrid model for light simulation. 
 }
 
 #source is now a root file

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
@@ -40,15 +40,14 @@ physics:
      IonAndScintExternal: @local::dunefdvd_ionandscint_external
      elecDrift:   @local::dunefd_elecdrift
      PDFastSimAr: @local::dunevd_pdfastsim_par_ar_fastonly
-     PDFastSimArExternal: @local::dunevd_pdfastsim_pvs_external
      PDFastSimXe: @local::dunevd_pdfastsim_par_xe
-     PDFastSimXeExternal: @local::dunevd_pdfastsim_pvs_external
+     PDFastSimExternal: @local::dunevd_pdfastsim_pvs_external
      rns:         { module_type: "RandomNumberSaver" }
   }
 
   #define the producer and filter modules for this path, order matters, 
   #filters reject all following items.  see lines starting physics.producers below
-  simulate: [ rns, largeant , IonAndScint, IonAndScintExternal, elecDrift, PDFastSimAr, PDFastSimXe, PDFastSimArExternal, PDFastSimXeExternal ]
+  simulate: [ rns, largeant , IonAndScint, IonAndScintExternal, elecDrift, PDFastSimAr, PDFastSimXe, PDFastSimExternal ]
  
   #define the output stream, there could be more than one if using filters 
   stream1:  [ out1 ]

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
@@ -16,6 +16,8 @@ services:
   FileCatalogMetadata:   @local::art_file_catalog_mc
 
   @table::dunefdvd_simulation_services
+  PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe 
+  # The PhotonVisibilityService is used for the hybrid model for light simulation. 
 }
 
 #source is now a root file

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view.fcl
@@ -3,5 +3,7 @@
 services: {
   @table::services
   @table::dunefdvd_1x8x14_3view_simulation_services
+  PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe 
+  # The PhotonVisibilityService is used for the hybrid model for light simulation. 
 }
 

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view.fcl
@@ -3,7 +3,5 @@
 services: {
   @table::services
   @table::dunefdvd_1x8x14_3view_simulation_services
-  PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe 
-  # The PhotonVisibilityService is used for the hybrid model for light simulation. 
 }
 

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view_30deg_ArOnly.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view_30deg_ArOnly.fcl
@@ -1,0 +1,3 @@
+#include "standard_g4_dunevd10kt_1x8x14_3view_30deg.fcl"
+
+services.PhotonVisibilityService.LibraryFile: "PhotonPropagation/LibraryData/Photon_library_dunevd10kt_3view_v2_refactored_1x8x14ref_ReflAnode_argon_non_active.root"

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view_30deg_XeOnly.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x14_3view_30deg_XeOnly.fcl
@@ -1,0 +1,3 @@
+#include "standard_g4_dunevd10kt_1x8x14_3view_30deg.fcl"
+
+services.PhotonVisibilityService.LibraryFile: "PhotonPropagation/LibraryData/Photon_library_dunevd10kt_3view_v2_refactored_1x8x14ref_ReflAnode_xenon_non_active.root"

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view.fcl
@@ -4,4 +4,6 @@ services: {
   @table::services
   @table::dunefdvd_1x8x6_3view_simulation_services
 }
+physics.producers.PDFastSimExternal: @erase
+physics.simulate: [ rns, largeant , IonAndScint, IonAndScintExternal, elecDrift, PDFastSimAr, PDFastSimXe ]
 

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view.fcl
@@ -4,6 +4,8 @@ services: {
   @table::services
   @table::dunefdvd_1x8x6_3view_simulation_services
 }
+
+# New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
 physics.producers.PDFastSimExternal: @erase
 physics.simulate: [ rns, largeant , IonAndScint, IonAndScintExternal, elecDrift, PDFastSimAr, PDFastSimXe ]
 

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -4,6 +4,8 @@ services: {
   @table::services
   @table::dunefdvd_1x8x6_3view_30deg_simulation_services
 }
+
+# New modifications since the hybrid model implementation in the VD-DUNE 1x8x14 geometry. 
 physics.producers.PDFastSimExternal: @erase
 physics.simulate: [ rns, largeant , IonAndScint, IonAndScintExternal, elecDrift, PDFastSimAr, PDFastSimXe ]
 

--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -4,4 +4,6 @@ services: {
   @table::services
   @table::dunefdvd_1x8x6_3view_30deg_simulation_services
 }
+physics.producers.PDFastSimExternal: @erase
+physics.simulate: [ rns, largeant , IonAndScint, IonAndScintExternal, elecDrift, PDFastSimAr, PDFastSimXe ]
 


### PR DESCRIPTION
In the `standard_g4_dunevd10kt.fcl`, the `PDFastSimArExternal` and `PDFastSimXeExternal` are merged to be `PDFastSimExternal` because of the current usage of the merged library for the hybrid model for the fast light simulation. `PhotonVisibilityService: @local::dune10kt_vd_1x8x14_photonvisibilityservice_ArXe` is added in the service to allow the usage of the library.

In the `standard_g4_dunevd10kt_1x8x6_3view.fcl` and `standard_g4_dunevd10kt_1x8x6_3view_30deg.fcl`, the light simulation in the non-active volume part is disabled. 