### PR TITLE
Rename the seed name to the one in IonizationScintillation.

### DIFF
--- a/test/ci/ci_test_g4_protoDUNEsp.fcl
+++ b/test/ci/ci_test_g4_protoDUNEsp.fcl
@@ -2,7 +2,7 @@
 
 services.NuRandomService.policy: "preDefinedSeed"
 services.NuRandomService.baseSeed: 1234
-services.NuRandomService.IonAndScint.NEST: 1234
+services.NuRandomService.IonAndScint.ISCalcAlg: 1234
 services.NuRandomService.PDFastSim.photon: 1234
 services.NuRandomService.PDFastSim.scinttime: 1234
 services.NuRandomService.largeant: 1234

--- a/test/ci/ci_test_g4_stage1_protoDUNEsp.fcl
+++ b/test/ci/ci_test_g4_stage1_protoDUNEsp.fcl
@@ -2,7 +2,7 @@
 
 services.NuRandomService.policy: "preDefinedSeed"
 services.NuRandomService.baseSeed: 1234
-services.NuRandomService.IonAndScint.NEST: 1234
+services.NuRandomService.IonAndScint.ISCalcAlg: 1234
 services.NuRandomService.PDFastSim.photon: 1234
 services.NuRandomService.PDFastSim.scinttime: 1234
 services.NuRandomService.largeant: 1234

--- a/test/ci/ci_test_g4_stage2_protoDUNEsp.fcl
+++ b/test/ci/ci_test_g4_stage2_protoDUNEsp.fcl
@@ -2,7 +2,6 @@
 
 services.NuRandomService.policy: "preDefinedSeed"
 services.NuRandomService.baseSeed: 1234
-services.NuRandomService.IonAndScint.NEST: 1234
 services.NuRandomService.IonAndScint.ISCalcAlg: 1234
 services.NuRandomService.PDFastSim.photon: 1234
 services.NuRandomService.PDFastSim.scinttime: 1234


### PR DESCRIPTION
To match changes made in: https://github.com/LArSoft/larsim/pull/97

In the pull request above I change the name of the seed used in the `IonizationScintillation` module, since a single seed could be used by either algorithm (Correlated or NEST).

This PR fixes: https://cdcvs.fnal.gov/redmine/issues/27310