### PR TITLE
Hybrid model for ProtoDUNE-HD

### DIFF
--- a/fcl/protodunehd/detsim/protoDUNEHD_refactored_detsim.fcl
+++ b/fcl/protodunehd/detsim/protoDUNEHD_refactored_detsim.fcl
@@ -1,6 +1,6 @@
 #include "services_refactored_pdune.fcl"
 #include "wirecell_dune.fcl"
-#include "opticaldetectormodules_dune.fcl"
+#include "WaveformDigitizerSim.fcl"
 #include "CRT.fcl"
 #include "tools_dune.fcl"
 
@@ -29,7 +29,7 @@ physics:
   producers:
   {
     tpcrawdecoder:  @local::wirecell_protodunehdmc
-    #opdigi:         @local::protodune_opdigi_refactor
+    opdigi:         @local::standard_daphne
     crt:            @local::CRTSimRefac_standard
     rns:            { module_type: "RandomNumberSaver" }
   }
@@ -38,7 +38,7 @@ physics:
               # TPC simulation
               tpcrawdecoder,
               # OpDet and CRT simulation
-              #opdigi,
+              opdigi,
               crt] 
   stream1:  [ out1 ]
 

--- a/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
+++ b/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
@@ -13,7 +13,6 @@ services:
   RandomNumberGenerator: {} #ART native random number generator
   message:      @local::standard_info
 
-  @table::protodunehd_larg4_services
   @table::protodunehd_refactored_simulation_services
 
   NuRandomService:       @local::dune_prod_seedservice

--- a/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
+++ b/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
@@ -36,8 +36,10 @@ physics:
 
     #retain largeant name for compatibility
     largeant:     @local::protodune_larg4
-    IonAndScint:  @local::protodunehd_ionandscint
-    #PDFastSim:    @local::protodune_pdfastsim_pvs
+    IonAndScint:  @local::protodunehd_ionandscint_external
+    IonAndScintExternal: @local::dunefdvd_ionandscint_external
+    PDFastSim:    @local::protodune_hd_pdfastsim_par
+    PDFastSimExternal: @local::protodune_hd_pdfastsim_pvs_external
     rns: {module_type: "RandomNumberSaver"}
   }
 
@@ -46,8 +48,8 @@ physics:
 
   }
 
-  #simulate:      [  rns, largeant, IonAndScint, PDFastSim ]
-  simulate:      [  rns, largeant, IonAndScint]
+  simulate:      [  rns, largeant, IonAndScint, IonAndScintExternal, PDFastSim, PDFastSimExternal ]
+  #simulate:      [  rns, largeant, IonAndScint]
 
   stream1:       [ out1 ]
 

--- a/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
+++ b/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
@@ -35,7 +35,7 @@ physics:
 
     #retain largeant name for compatibility
     largeant:     @local::protodune_larg4
-    IonAndScint:  @local::protodunehd_ionandscint_external
+    IonAndScint:  @local::protodunehd_ionandscint
     IonAndScintExternal: @local::protodunehd_ionandscint_external
     PDFastSim:    @local::protodune_hd_pdfastsim_par
     PDFastSimExternal: @local::protodune_hd_pdfastsim_pvs_external

--- a/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
+++ b/fcl/protodunehd/g4/protoDUNEHD_refactored_g4.fcl
@@ -37,7 +37,7 @@ physics:
     #retain largeant name for compatibility
     largeant:     @local::protodune_larg4
     IonAndScint:  @local::protodunehd_ionandscint_external
-    IonAndScintExternal: @local::dunefdvd_ionandscint_external
+    IonAndScintExternal: @local::protodunehd_ionandscint_external
     PDFastSim:    @local::protodune_hd_pdfastsim_par
     PDFastSimExternal: @local::protodune_hd_pdfastsim_pvs_external
     rns: {module_type: "RandomNumberSaver"}

--- a/fcl/protodunehd/g4/protoDUNEHD_refactored_g4_stage2.fcl
+++ b/fcl/protodunehd/g4/protoDUNEHD_refactored_g4_stage2.fcl
@@ -43,8 +43,8 @@ physics:
 
   }
 
-  #simulate:      [  rns, IonAndScint, PDFastSim ]
-  simulate:      [  rns, IonAndScint]
+  simulate:      [  rns, largeant, IonAndScint, IonAndScintExternal, PDFastSim, PDFastSimExternal ]
+  # simulate:      [  rns, IonAndScint]
 
   stream1:       [ out1 ]
 

--- a/fcl/protodunehd/g4/protoDUNEHD_refactored_g4_stage2.fcl
+++ b/fcl/protodunehd/g4/protoDUNEHD_refactored_g4_stage2.fcl
@@ -35,7 +35,9 @@ physics:
     #retain largeant name for compatibility
     rns: {module_type: "RandomNumberSaver"}
     IonAndScint:  @local::protodunehd_ionandscint
-    #PDFastSim:    @local::protodune_pdfastsim_pvs
+    IonAndScintExternal: @local::protodunehd_ionandscint_external
+    PDFastSim:    @local::protodune_hd_pdfastsim_par
+    PDFastSimExternal: @local::protodune_hd_pdfastsim_pvs_external
   }
 
   analyzers:


### PR DESCRIPTION
Changed the digitiser to be DAPHNE, added relevant fast optical simulation producers. 