### PR TITLE
Including Ar late component for Xe 10ppm

### DIFF
--- a/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
+++ b/fcl/dunefdvd/g4/standard_g4_dunevd10kt.fcl
@@ -37,7 +37,7 @@ physics:
      IonAndScint: @local::dunefdvd_ionandscint
      IonAndScintExternal: @local::dunefdvd_ionandscint_external
      elecDrift:   @local::dunefd_elecdrift
-     PDFastSimAr: @local::dunevd_pdfastsim_par_ar_fastonly
+     PDFastSimAr: @local::dunevd_pdfastsim_par_ar
      PDFastSimXe: @local::dunevd_pdfastsim_par_xe
      PDFastSimExternal: @local::dunevd_pdfastsim_pvs_external
      rns:         { module_type: "RandomNumberSaver" }


### PR DESCRIPTION
Simulation of Xe doped Ar (at 10ppm) is no longer simulated as having late Ar light fully transferred to Xe emission.