### PR TITLE
fixed typo in detsim fcl from 1x2x6 -> 1x2x2

### DIFF
--- a/fcl/dunefd/detsim/detsim_dune10kt_1x2x2_wirecell_refactored.fcl
+++ b/fcl/dunefd/detsim/detsim_dune10kt_1x2x2_wirecell_refactored.fcl
@@ -9,5 +9,5 @@ services:
 physics.producers: 
 {
     @table::physics.producers
-    tpcrawdecoder: @local::tpcrawdecoder_dunefd_horizdrift_1x2x6
+    tpcrawdecoder: @local::tpcrawdecoder_dunefd_horizdrift_1x2x2
 }


### PR DESCRIPTION
fixed a typo in detsim_dune10kt_1x2x2_wirecell_refactored.fcl replacing 1x2x6 with 1x2x2.