### PR TITLE
Expand (and bug fix) 1d signal processing workflow

### DIFF
--- a/fcl/dunefd/reco/reco1_1dsignalprocessing_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/reco/reco1_1dsignalprocessing_dune10kt_1x2x6.fcl
@@ -1,0 +1,5 @@
+#include "standard_reco1_dune10kt_1x2x6.fcl"
+
+physics.reco: [ caldata, @sequence::physics.reco ]
+
+physics.producers.gaushit.CalDataModuleLabel: "caldata"

--- a/fcl/dunefd/reco/reco1_dune10kt_1x2x6_tpcsigproc.fcl
+++ b/fcl/dunefd/reco/reco1_dune10kt_1x2x6_tpcsigproc.fcl
@@ -1,6 +1,6 @@
 #include "standard_reco1_dune10kt_1x2x6.fcl"
 
-physics.reco: [ wclsmcnfsp, @sequence::physics.reco1 ]
+physics.reco: [ wclsmcnfsp, @sequence::physics.reco ]
 
 dunefd_horizdrift_producers.gaushit.CalDataModuleLabel: "wclsmcnfsp:gauss"
 

--- a/fcl/dunefd/reco/reco2_1dsignalprocessing_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/reco/reco2_1dsignalprocessing_dune10kt_1x2x6.fcl
@@ -1,0 +1,8 @@
+#include "standard_reco2_dune10kt_1x2x6.fcl"
+
+physics.producers.pmtrack.WireModuleLabel:    "caldata"
+physics.producers.pmtracktc.WireModuleLabel:  "caldata"
+physics.producers.emtrkmichelid.WireLabel:    "caldata"
+physics.producers.energyrecnumu.WireLabel:    "caldata"
+physics.producers.energyrecnue.WireLabel:     "caldata"
+physics.producers.energyrecnc.WireLabel:      "caldata"

--- a/fcl/dunefd/reco/reco_1dsignalprocessing_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/reco/reco_1dsignalprocessing_dune10kt_1x2x6.fcl
@@ -1,4 +1,4 @@
-#include "standard_reco1_dune10kt_1x2x6.fcl"
+#include "standard_reco_dune10kt_1x2x6.fcl"
 
 physics.reco: [ caldata, @sequence::physics.reco ]
 

--- a/fcl/dunefd/reco/reco_1dsignalprocessing_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/reco/reco_1dsignalprocessing_dune10kt_1x2x6.fcl
@@ -1,4 +1,4 @@
-#include "reco1_dune10kt_1x2x6_tpcsigproc.fcl"
+#include "standard_reco1_dune10kt_1x2x6.fcl"
 
 physics.reco: [ caldata, @sequence::physics.reco ]
 


### PR DESCRIPTION
This PR adds reco1 and reco2 workflows that use older 1D signal processing.
This PR also fixes the overall reco fcl that uses the 1D signal processing.