### PR TITLE
remove #include of services_dune.fcl in protodune reco fcl

### DIFF
--- a/fcl/protodune/reco/protoDUNE_reco_data_Dec2018.fcl
+++ b/fcl/protodune/reco/protoDUNE_reco_data_Dec2018.fcl
@@ -1,6 +1,5 @@
 ## protoDUNE reco on data for Dec 2018 production
 
-#include "services_dune.fcl"
 #include "RawDecoder.fcl"
 #include "BeamEvent.fcl"
 #include "caldata_dune.fcl"


### PR DESCRIPTION
wirecell_dune.fcl already includes services_dune.fcl and it gets included twice.  services_dune.fcl itself causes many duplicate includes of other files, but removing this include heads off a lot of multiple inclusions