### PR TITLE
Fixing pandora MCParticles in standard_reco_atmos_dune10kt_1x2x6.fcl

### DIFF
--- a/fcl/dunefd/reco/standard_reco_atmos_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/reco/standard_reco_atmos_dune10kt_1x2x6.fcl
@@ -2,3 +2,4 @@
 
 physics.producers.pandora.ConfigFile:   "PandoraSettings_Master_Atmos_DUNEFD.xml"
 physics.producers.pandora.EnableMCParticles:   true
+physics.producers.pandora.SimChannelModuleLabel: "tpcrawdecoder:simpleSC"


### PR DESCRIPTION
Just a quick fix of `standard_reco_atmos_dune10kt_1x2x6.fcl` to define the right `SimChannelModuleLabel` for pandora and avoid raising an exception.