### PR TITLE
Adding a GENIE stage for atmospherics with ramdom RNG policy

### DIFF
--- a/fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_dune10kt_1x2x6.fcl
@@ -1,3 +1,3 @@
-#include "prodgenie_atmnu_max_dune10kt_1x2x6.fcl"
+#include "prodgenie_atmnu_max_weighted_dune10kt_1x2x6.fcl"
 
 services.NuRandomService: @local::random_NuRandomService #Using the random rng policy

--- a/fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_dune10kt_1x2x6.fcl
@@ -1,0 +1,3 @@
+#include "prodgenie_atmnu_max_dune10kt_1x2x6.fcl"
+
+services.NuRandomService: @local::random_NuRandomService #Using the random rng policy


### PR DESCRIPTION
Following the discovery of a weird interplay between the `perEvent` RNG policy and the sequence of numbers generated by the atmospherics flux driver (similar sequence starts across different runs), this PR aims at providing a new fcl file for the atmospherics production where the `random` policy is used to go around this issue.

This change should only fix the beahaviour of the flux driver to obtain "truly" random seeds, without any additional effect.