### PR TITLE
Minor update to protodune-vd detsim CRTs

### DIFF
--- a/fcl/protodunevd/detsim/protodunevd_detsim.fcl
+++ b/fcl/protodunevd/detsim/protodunevd_detsim.fcl
@@ -33,13 +33,14 @@ physics:
   {
     tpcrawdecoder:  @local::wirecell_protodunevd_mc
     # opdigi:         @local::protodune_opdigi_refactor
-     crt:            @local::CRTVD_simrefac
+    crt:            @local::CRTVD_simrefac
     rns:            { module_type: "RandomNumberSaver" }
   }
 
   simulate: [ rns,
-              tpcrawdecoder,
-              crt]
+              tpcrawdecoder
+              #crt
+              ]
   stream1:  [ out1 ]
 
   trigger_paths: [simulate]

--- a/fcl/protodunevd/detsim/protodunevd_refactored_detsim.fcl
+++ b/fcl/protodunevd/detsim/protodunevd_refactored_detsim.fcl
@@ -36,10 +36,11 @@ physics:
   
   simulate: [ rns, 
               # TPC simulation
-              tpcrawdecoder,
+              tpcrawdecoder
               # OpDet and CRT simulation
               # opdigi,
-               crt] 
+              # crt
+               ] 
   stream1:  [ out1 ]
 
   trigger_paths: [simulate] 

--- a/fcl/protodunevd/detsim/protodunevd_refactored_detsim_driftY.fcl
+++ b/fcl/protodunevd/detsim/protodunevd_refactored_detsim_driftY.fcl
@@ -41,7 +41,7 @@ physics:
   
   simulate: [ rns, 
               ## TPC simulation
-#              tpcrawdecoder,
+              tpcrawdecoder,
               ## OpDet and CRT simulation
               # opdigi,
                crt] 


### PR DESCRIPTION
Following the talk in https://indico.fnal.gov/event/61808/, the crt simulation is remained activated in the protodune-vd driftY workflow, but switched off in the driftX workflow, waiting for overlap issues of CRT volumes to be solved in the gdml file.