### PR TITLE
Reco2 fcls using older geometry versions (FD1-HD and FD2-VD)

### DIFF
--- a/fcl/dunefd/reco/reco2_dune10kt_nu_1x2x6_geov4.fcl
+++ b/fcl/dunefd/reco/reco2_dune10kt_nu_1x2x6_geov4.fcl
@@ -1,0 +1,3 @@
+#include "standard_reco2_dune10kt_nu_1x2x6.fcl"
+
+services.Geometry: @local::dune10kt_1x2x6_v4_refactored_geo

--- a/fcl/dunefdvd/reco/reco2_dunevd10kt_1x8x6_3view_30deg_geov3.fcl
+++ b/fcl/dunefdvd/reco/reco2_dunevd10kt_1x8x6_3view_30deg_geov3.fcl
@@ -1,0 +1,3 @@
+#include "standard_reco2_dunevd10kt_1x8x6_3view_30deg.fcl"
+
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo


### PR DESCRIPTION
Phase 1 of the LBL production used different versions of the geometry for FHC and RHC in FD1-HD, as the geometry version got bumped before the patch release needed to process RHC.
Separately, FD2-VD's geometry version has been bumped a few times since phase 1 of the LBL production.

This PR includes two fcls to run reco2 using older versions of the geometry that were used during phase 1 of the LBL production.