### PR TITLE
Dedicated 1x8x6 workflow for reco2 (disables PDS)

### DIFF
--- a/fcl/dunefdvd/reco/standard_reco2_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/reco/standard_reco2_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -13,7 +13,7 @@ services.TFileService.fileName: "reco2_hist.root"
 
 source.inputCommands: ["keep *_*_*_*", "drop *_*_*_Reco2" ]
 
-physics.reco: [ @sequence::dunefd_vertdrift_reco2 ]
+physics.reco: [ @sequence::dunefd_vertdrift_1x8x6_reco2 ]
 
 outputs.out1.fileName: "%ifb_reco2.root"
 outputs.out1.dataTier: "full-reconstructed"

--- a/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
+++ b/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
@@ -99,6 +99,11 @@ dunefd_vertdrift_reco2:
     @sequence::dunefd_vertdrift_pds_reco2
 ]
 
+dunefd_vertdrift_1x8x6_reco2:
+[
+    @sequence::dunefd_vertdrift_tpc_reco2
+]
+
 dunefd_vertdrift_tpc:
 [
     @sequence::dunefd_vertdrift_tpc_reco1,


### PR DESCRIPTION
VD high level PDS reco has been tripping over causing 1x8x6 reco2 jobs to fail.  
The low light yield in the 1x8x6 means that the PDS system is less useful in this geometry so it should just be disabled (it remains enabled in the 1x8x14)