### PR TITLE
Create new reco fcls to incorporate FHC/RHC CVN for LBL

### DIFF
--- a/fcl/dunefd/reco/standard_reco2_dune10kt_anu_1x2x6.fcl
+++ b/fcl/dunefd/reco/standard_reco2_dune10kt_anu_1x2x6.fcl
@@ -1,0 +1,7 @@
+# Anti-neutrino LBNF reconstruction fcl
+# author: Dom Brailsford
+# date: 23rd Nov 2023
+
+#include "standard_reco2_dune10kt_nu_1x2x6.fcl"
+
+physics.producers.cvneva: @local::dunehd_1x2x6_RHC_cvnevaluator

--- a/fcl/dunefd/reco/standard_reco2_dune10kt_nu_1x2x6.fcl
+++ b/fcl/dunefd/reco/standard_reco2_dune10kt_nu_1x2x6.fcl
@@ -13,3 +13,5 @@ physics.producers.pmtrackcalo.Flip_dQdx: false
 physics.producers.pmtrajfitcalo.Flip_dQdx: false
 physics.producers.pmtracktccalo.Flip_dQdx: false
 physics.producers.pmtrajfittccalo.Flip_dQdx: false
+physics.producers.cvnmap: @local::dunehd_1x2x6_cvnmapper
+physics.producers.cvneva: @local::dunehd_1x2x6_FHC_cvnevaluator

--- a/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
+++ b/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
@@ -66,8 +66,8 @@ dunefd_horizdrift_producers:
   emshower:                @local::dune10kt_emshower
   emtrkmichelid:           @local::standard_emtrackmichelid
   #cvn
-  cvnmap:                @local::dunefd_horizdrift_cvnmapper
-  cvneva:                @local::dunefd_horizdrift_cvnevaluator
+  cvnmap:                @local::dunehd_1x2x6_cvnmapper 
+  cvneva:                @local::dunehd_1x2x6_FHC_cvnevaluator
   #neutrino energy reco
   energyrecnumu:        @local::dunefd_nuenergyreco_pandora_numu
   energyrecnue:          @local::dunefd_nuenergyreco_pandora_nue

--- a/fcl/dunefdvd/reco/reco2_dunevd10kt_anu_1x8x6_3view_30deg_geov3.fcl
+++ b/fcl/dunefdvd/reco/reco2_dunevd10kt_anu_1x8x6_3view_30deg_geov3.fcl
@@ -1,0 +1,3 @@
+#include "standard_reco2_dunevd10kt_anu_1x8x6_3view_30deg.fcl"
+
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo

--- a/fcl/dunefdvd/reco/reco2_dunevd10kt_nu_1x8x6_3view_30deg_geov3.fcl
+++ b/fcl/dunefdvd/reco/reco2_dunevd10kt_nu_1x8x6_3view_30deg_geov3.fcl
@@ -1,0 +1,3 @@
+#include "standard_reco2_dunevd10kt_nu_1x8x6_3view_30deg.fcl"
+
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo

--- a/fcl/dunefdvd/reco/standard_reco2_dunevd10kt_anu_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/reco/standard_reco2_dunevd10kt_anu_1x8x6_3view_30deg.fcl
@@ -1,0 +1,7 @@
+# Antineutrino reconstruction 2 fcl for LBL
+# author: Dom Brailsford
+# date: 23rd Nov 2023
+
+#include "standard_reco2_dunevd10kt_nu_1x8x6_3view_30deg.fcl"
+
+physics.producers.cvneva: @local::dunevd_8x6_RHC_cvnevaluator

--- a/fcl/dunefdvd/reco/standard_reco2_dunevd10kt_nu_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/reco/standard_reco2_dunevd10kt_nu_1x8x6_3view_30deg.fcl
@@ -1,0 +1,8 @@
+# Reconstruction 2 fcl for LBNF neutrinos
+# author: Dom Brailsford
+# date: 23rd November 2023
+
+#include "standard_reco2_dunevd10kt_1x8x6_3view_30deg.fcl"
+#
+physics.producers.cvnmap:      @local::dunevd_8x6_cvnmapper
+physics.producers.cvneva:      @local::dunevd_8x6_FHC_cvnevaluator

--- a/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
+++ b/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
@@ -32,7 +32,7 @@ dunefd_vertdrift_producers:
    pandoracalo:        @local::dunevd10kt_calomc_pandora
    pandorapid:         @local::dunevd10kt_pid_pandora
    cvnmap:             @local::dunevd_8x6_cvnmapper
-   cvneval:            @local::dunevd_8x6_FHC_cvnevaluator
+   cvneva:            @local::dunevd_8x6_FHC_cvnevaluator
    # Neutrino energy
    energyrecnumu:         @local::dunefdvd_nuenergyreco_pandora_numu
    energyrecnue:          @local::dunefdvd_nuenergyreco_pandora_nue
@@ -87,7 +87,7 @@ dunefd_vertdrift_tpc_reco2:
     pandoracalo,
     pandorapid,
     cvnmap,
-    cvneval,
+    cvneva,
     energyrecnumu,
     energyrecnue,
     energyrecnc

--- a/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
+++ b/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
@@ -31,8 +31,8 @@ dunefd_vertdrift_producers:
    # PID
    pandoracalo:        @local::dunevd10kt_calomc_pandora
    pandorapid:         @local::dunevd10kt_pid_pandora
-   cvnmap:             @local::dunevd10kt_cvnmapper
-   cvneval:            @local::dunevd10kt_3view_cvnevaluator
+   cvnmap:             @local::dunevd_8x6_cvnmapper
+   cvneval:            @local::dunevd_8x6_FHC_cvnevaluator
    # Neutrino energy
    energyrecnumu:         @local::dunefdvd_nuenergyreco_pandora_numu
    energyrecnue:          @local::dunefdvd_nuenergyreco_pandora_nue


### PR DESCRIPTION
PR depends on: https://github.com/DUNE/dunereco/pull/74

This PR ultimately incorporates the latest CVN trainings for HD and VD.
To accommodate neutrino and antineutrino reconstructions it was desirable to create a 'nu' reco2 fcl for VD so that there could be an equivalent 'anu' fcl.

For both VD and HD, the new trainings have been connected up to the general workflow.  The new training have also been explicitly connected up to the workspace geometry workflows (this step is technically redundant as the workspace workflows inherit from the general workflow, but its possible we'll update the general workflow to use a different training when we having the full 10kt workflows up and running)

geov3 VD reco2 fcls are also provided as those are needed for the LBL production