### PR TITLE
VD 1x8x6 30 deg geov3 anatree fcl

### DIFF
--- a/fcl/dunefdvd/anatree/anatree_dunevd10kt_1x8x6_3view_30deg_geov3.fcl
+++ b/fcl/dunefdvd/anatree/anatree_dunevd10kt_1x8x6_3view_30deg_geov3.fcl
@@ -1,0 +1,3 @@
+#include "standard_anatree_dunevd10kt_1x8x6_3view_30deg.fcl"
+
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo


### PR DESCRIPTION
This PR includes a new anatree fcl that uses the v3 version of the 1x8x6_30deg vd geometry, needed for the LBL production