### PR TITLE
Update PDVD sim/reco for MC validation samples production

### DIFF
--- a/fcl/protodunevd/detsim/protodunevd_refactored_detsim_nodiffusion_03mslifetime.fcl
+++ b/fcl/protodunevd/detsim/protodunevd_refactored_detsim_nodiffusion_03mslifetime.fcl
@@ -1,0 +1,10 @@
+#include "protodunevd_refactored_detsim.fcl"
+
+# Longitudinal diffusion constant [cm2/s]
+physics.producers.tpcrawdecoder.wcls_main.structs.DL: 0.0
+
+# Transverse diffusion constant [cm2/s]
+physics.producers.tpcrawdecoder.wcls_main.structs.DT: 0.0
+
+# Electron lifetime [ms]
+physics.producers.tpcrawdecoder.wcls_main.structs.lifetime: 3000 

--- a/fcl/protodunevd/detsim/protodunevd_refactored_detsim_nodiffusion_35mslifetime.fcl
+++ b/fcl/protodunevd/detsim/protodunevd_refactored_detsim_nodiffusion_35mslifetime.fcl
@@ -1,0 +1,10 @@
+#include "protodunevd_refactored_detsim.fcl"
+
+# Longitudinal diffusion constant [cm2/s]
+physics.producers.tpcrawdecoder.wcls_main.structs.DL: 0.0
+
+# Transverse diffusion constant [cm2/s]
+physics.producers.tpcrawdecoder.wcls_main.structs.DT: 0.0
+
+# Electron lifetime [ms]
+physics.producers.tpcrawdecoder.wcls_main.structs.lifetime: 35000 

--- a/fcl/protodunevd/detsim/protodunevd_refactored_detsim_nodiffusion_inflifetime.fcl
+++ b/fcl/protodunevd/detsim/protodunevd_refactored_detsim_nodiffusion_inflifetime.fcl
@@ -1,0 +1,10 @@
+#include "protodunevd_refactored_detsim.fcl"
+
+# Longitudinal diffusion constant [cm2/s]
+physics.producers.tpcrawdecoder.wcls_main.structs.DL: 0.0
+
+# Transverse diffusion constant [cm2/s]
+physics.producers.tpcrawdecoder.wcls_main.structs.DT: 0.0
+
+# Electron lifetime [ms]
+physics.producers.tpcrawdecoder.wcls_main.structs.lifetime: 1e100 

--- a/fcl/protodunevd/g4/protodunevd_refactored_g4_stage1.fcl
+++ b/fcl/protodunevd/g4/protodunevd_refactored_g4_stage1.fcl
@@ -11,6 +11,7 @@ services:
   RandomNumberGenerator: {} #ART native random number generator
   message:      @local::standard_info
 
+  @table::protodunevd_refactored_simulation_services
   @table::protodunevd_larg4_services
 
   NuRandomService:       @local::dune_prod_seedservice

--- a/fcl/protodunevd/g4/protodunevd_refactored_g4_stage2.fcl
+++ b/fcl/protodunevd/g4/protodunevd_refactored_g4_stage2.fcl
@@ -26,13 +26,16 @@ source:
   fileNames: ["g4_stage1_protoDUNE.root"]
 }
 
+protodunevd_ionandscint_active: @local::protodunevd_ionandscint
+protodunevd_ionandscint_active.Instances:    "LArG4DetectorServicevolTPCActive"
+
 physics:
 {
 
   producers:
   {
     rns: {module_type: "RandomNumberSaver"}
-    IonAndScint:  @local::protodunevd_ionandscint
+    IonAndScint:  @local::protodunevd_ionandscint_active
     #PDFastSim:    @local::protodune_pdfastsim_pvs
   }
 

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio.fcl
@@ -36,11 +36,15 @@ physics:
  producers:
  {
    cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   ar39:  @local::protodunesp_39ar
+   ar42:  @local::protodunesp_42ar
+   kr85:  @local::protodunesp_85kr
+   rn222: @local::protodunesp_222rn
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+ simulate: [ cosmicgenerator, ar39, ar42, kr85, rn222 ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +72,6 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_cosmics_radio_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_cosmics_radio.root"

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_electron_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_electron_1GeV.fcl
@@ -3,6 +3,7 @@
 #include "corsika_protodune.fcl"
 #include "CORSIKAGendp.fcl"
 #include "dune_radiological_model.fcl"
+#include "gen_protodunevd_singlep.fcl"
 
 process_name: SinglesGen
 
@@ -35,12 +36,17 @@ physics:
 
  producers:
  {
+   generator: @local::pdvd_1GeV_electron
    cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   ar39:  @local::protodunesp_39ar
+   ar42:  @local::protodunesp_42ar
+   kr85:  @local::protodunesp_85kr
+   rn222: @local::protodunesp_222rn
  }
 
 
- #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+ #define the producer, and filter modules for this path, order matters,
+simulate: [ generator, cosmicgenerator, ar39, ar42, kr85, rn222 ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +74,7 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_cosmics_radio_electron_1GeV_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_cosmics_radio_electron_1GeV.root"
+

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_kaon_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_kaon_1GeV.fcl
@@ -3,6 +3,7 @@
 #include "corsika_protodune.fcl"
 #include "CORSIKAGendp.fcl"
 #include "dune_radiological_model.fcl"
+#include "./gen_protodunevd_singlep.fcl"
 
 process_name: SinglesGen
 
@@ -35,12 +36,17 @@ physics:
 
  producers:
  {
+   generator: @local::pdvd_1GeV_kaon
    cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   ar39:  @local::protodunesp_39ar
+   ar42:  @local::protodunesp_42ar
+   kr85:  @local::protodunesp_85kr
+   rn222: @local::protodunesp_222rn
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+simulate: [ generator, cosmicgenerator, ar39, ar42, kr85, rn222 ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +74,7 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_cosmics_radio_kaon_1GeV_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_cosmics_radio_kaon_1GeV.root"
+

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_pion_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_pion_1GeV.fcl
@@ -3,6 +3,7 @@
 #include "corsika_protodune.fcl"
 #include "CORSIKAGendp.fcl"
 #include "dune_radiological_model.fcl"
+#include "./gen_protodunevd_singlep.fcl"
 
 process_name: SinglesGen
 
@@ -35,12 +36,19 @@ physics:
 
  producers:
  {
+   # cosmicgenerator: @local::protodune_corsika_cmc
+   generator: @local::pdvd_1GeV_pion
    cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   ar39:  @local::protodunesp_39ar
+   ar42:  @local::protodunesp_42ar
+   kr85:  @local::protodunesp_85kr
+   rn222: @local::protodunesp_222rn
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+simulate: [ generator, cosmicgenerator, ar39, ar42, kr85, rn222 ]
+#simulate: [ generator, cosmicgenerator]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +76,7 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_cosmics_radio_pion_1GeV_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_cosmics_radio_pion_1GeV.root"
+

--- a/fcl/protodunevd/gen/gen_protodunevd_electron_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_electron_1GeV.fcl
@@ -3,6 +3,7 @@
 #include "corsika_protodune.fcl"
 #include "CORSIKAGendp.fcl"
 #include "dune_radiological_model.fcl"
+#include "gen_protodunevd_singlep.fcl"
 
 process_name: SinglesGen
 
@@ -35,12 +36,12 @@ physics:
 
  producers:
  {
-   cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   generator: @local::pdvd_1GeV_electron
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+simulate: [ generator ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +69,7 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_electron_1GeV_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_electron_1GeV.root"
+

--- a/fcl/protodunevd/gen/gen_protodunevd_kaon_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_kaon_1GeV.fcl
@@ -3,6 +3,7 @@
 #include "corsika_protodune.fcl"
 #include "CORSIKAGendp.fcl"
 #include "dune_radiological_model.fcl"
+#include "gen_protodunevd_singlep.fcl"
 
 process_name: SinglesGen
 
@@ -35,12 +36,12 @@ physics:
 
  producers:
  {
-   cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   generator: @local::pdvd_1GeV_kaon
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+simulate: [ generator ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +69,7 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_kaon_1GeV_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_kaon_1GeV.root"
+

--- a/fcl/protodunevd/gen/gen_protodunevd_pion_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_pion_1GeV.fcl
@@ -3,6 +3,7 @@
 #include "corsika_protodune.fcl"
 #include "CORSIKAGendp.fcl"
 #include "dune_radiological_model.fcl"
+#include "gen_protodunevd_singlep.fcl"
 
 process_name: SinglesGen
 
@@ -35,12 +36,12 @@ physics:
 
  producers:
  {
-   cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   generator: @local::pdvd_1GeV_pion
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+simulate: [ generator ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +69,7 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_pion_1GeV_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_pion_1GeV.root"
+

--- a/fcl/protodunevd/gen/gen_protodunevd_radio.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_radio.fcl
@@ -35,12 +35,15 @@ physics:
 
  producers:
  {
-   cosmicgenerator: @local::standard_CORSIKAGendp_CMC
+   ar39:  @local::protodunesp_39ar
+   ar42:  @local::protodunesp_42ar
+   kr85:  @local::protodunesp_85kr
+   rn222: @local::protodunesp_222rn
  }
 
 
  #define the producer and filter modules for this path, order matters,
-simulate: [ cosmicgenerator]
+ simulate: [ ar39, ar42, kr85, rn222 ]
 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
@@ -68,6 +71,6 @@ outputs:
  }
 }
 
-services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
+services.TFileService.fileName: "gen_protodunevd_radio_hist.root"
 source.maxEvents: 1
-outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+outputs.out1.fileName: "gen_protodunevd_radio.root"

--- a/fcl/protodunevd/gen/gen_protodunevd_singlep.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_singlep.fcl
@@ -1,0 +1,42 @@
+BEGIN_PROLOG
+
+pdvd_1GeV_electron:
+{
+ module_type:           "SingleGen"
+ ParticleSelectionMode: "all"       # 0 = use full list, 1 =  randomly select a single listed particle
+ PadOutVectors:		false	    # false: require all vectors to be same length
+                                    # true:  pad out if a vector is size one	
+ PDG:                   [ 11 ]      
+
+ P0:                    [ 1.0 ]     
+ SigmaP:                [ 0.0 ]       
+ PDist:                 "Gaussian"                                 
+
+ X0:                    [ 94.8 ]                                           
+ Y0:                    [ -142.6 ]    
+ Z0:                    [ 299.3 ]                                                               
+ T0:                    [ 0.0 ]     
+ Theta0XZ:              [ -169.175 ]                                         
+ Theta0YZ:              [ 44.486 ]                                          
+
+ SigmaX:                [ 0.0 ]     
+ SigmaY:                [ 0.0 ]                                 
+ SigmaZ:                [ 0.0 ]                                
+ SigmaT:                [ 0.0 ]    
+ SigmaThetaXZ:          [ 0.0 ]                                                             
+ SigmaThetaYZ:          [ 0.0 ]                                                            
+
+ PosDist:               "uniform"  
+ TDist:                 "uniform"           
+
+ AngleDist:             "Gaussian"  
+}
+
+pdvd_1GeV_kaon: @local::pdvd_1GeV_electron
+pdvd_1GeV_kaon.PDG: [321]
+
+pdvd_1GeV_pion: @local::pdvd_1GeV_electron
+pdvd_1GeV_pion.PDG: [211]
+
+
+END_PROLOG


### PR DESCRIPTION
The PR contains two parts:

1. Bug fixes of G4 stages when passing from v09_81_00d02 to v09_82_00d00
2. FHICL files that will be used to generate MC validation samples of cosmics, radiologicals and 1 GeV/c charged particles.