### PR TITLE
Added detsim and reco light-only fhicls for the 1x2x6 HD geometry

### DIFF
--- a/fcl/dunefd/detsim/standard_detsim_dune10kt_1x2x6_light.fcl
+++ b/fcl/dunefd/detsim/standard_detsim_dune10kt_1x2x6_light.fcl
@@ -1,17 +1,3 @@
 #include "standard_detsim_dune10kt_1x2x6.fcl"
 
-physics:
-{
-    @table::physics
-    producers:
-    {
-      @table::physics.producers
-    }
-
-#    Set up of PDS only digitizer in 1x2x6 geo
-    simulate: 
-    [
-    opdigi,
-    rns
-    ]
-}
+physics.simulate: [ opdigi, rns ]

--- a/fcl/dunefd/detsim/standard_detsim_dune10kt_1x2x6_light.fcl
+++ b/fcl/dunefd/detsim/standard_detsim_dune10kt_1x2x6_light.fcl
@@ -1,0 +1,17 @@
+#include "standard_detsim_dune10kt_1x2x6.fcl"
+
+physics:
+{
+    @table::physics
+    producers:
+    {
+      @table::physics.producers
+    }
+
+#    Set up of PDS only digitizer in 1x2x6 geo
+    simulate: 
+    [
+    opdigi,
+    rns
+    ]
+}

--- a/fcl/dunefd/reco/standard_reco_dune10kt_1x2x6_light.fcl
+++ b/fcl/dunefd/reco/standard_reco_dune10kt_1x2x6_light.fcl
@@ -7,8 +7,6 @@ physics:
    #  Set up of PDS only reconstruction in 1x2x6 geo
   reco: 
   [
-    # @sequence::dunefd_horizdrift_lowlevelreco,
-    # @sequence::dunefd_horizdrift_hitdisambiguation,
     @sequence::dunefd_horizdrift_pd_reco1,
     @sequence::dunefd_horizdrift_pd_reco2,
     rns

--- a/fcl/dunefd/reco/standard_reco_dune10kt_1x2x6_light.fcl
+++ b/fcl/dunefd/reco/standard_reco_dune10kt_1x2x6_light.fcl
@@ -1,15 +1,8 @@
 #include "standard_reco2_dune10kt_1x2x6.fcl"
 
-physics:
-{
-  @table::physics
-
-   #  Set up of PDS only reconstruction in 1x2x6 geo
-  reco: 
-  [
-    @sequence::dunefd_horizdrift_pd_reco1,
-    @sequence::dunefd_horizdrift_pd_reco2,
-    rns
-  ]
-
-}
+physics.reco: 
+[
+  @sequence::dunefd_horizdrift_pd_reco1,
+  @sequence::dunefd_horizdrift_pd_reco2,
+  rns
+]

--- a/fcl/dunefd/reco/standard_reco_dune10kt_1x2x6_light.fcl
+++ b/fcl/dunefd/reco/standard_reco_dune10kt_1x2x6_light.fcl
@@ -1,0 +1,17 @@
+#include "standard_reco2_dune10kt_1x2x6.fcl"
+
+physics:
+{
+  @table::physics
+
+   #  Set up of PDS only reconstruction in 1x2x6 geo
+  reco: 
+  [
+    # @sequence::dunefd_horizdrift_lowlevelreco,
+    # @sequence::dunefd_horizdrift_hitdisambiguation,
+    @sequence::dunefd_horizdrift_pd_reco1,
+    @sequence::dunefd_horizdrift_pd_reco2,
+    rns
+  ]
+
+}


### PR DESCRIPTION
Added detsim and reco light-only fhicls for the 1x2x6 HD geometry, in analogy to the already existing light-only fhicls for 1x8x14 VD.