### PR TITLE
Job fcl to run a neutron filter in the HD 1x2x6 supernova g4 workflow

### DIFF
--- a/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
@@ -1,0 +1,19 @@
+# supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
+# Author: Dom Brailsford (2024)
+# Purpose: Run the supernova g4 HD 1x2x6 jobset and reject any events that do not have a neutron stopping in the TPC 
+#
+# V1.0
+#
+
+#include "supernova_g4_dune10kt_1x2x6.fcl"
+#include "larg4particlefilter_dune.fcl"
+
+
+#Define the neutron filter
+physics.filters.neutronfilter:  @local::dunefd_neutrontpcfilter
+
+#Run neutron filter at the end
+physics.simulate:  [ @sequence:: physics.simulate, neutronfilter ]
+
+#Tell ART to actually filter using the ART filter
+outputs.out1.SelectEvents: [ neutronfilter ]

--- a/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
@@ -16,4 +16,4 @@ physics.filters.neutronfilter:  @local::dunefd_neutrontpcfilter
 physics.simulate:  [ @sequence::physics.simulate, neutronfilter ]
 
 #Tell ART to actually filter using the ART filter
-outputs.out1.SelectEvents: [ neutronfilter ]
+outputs.out1.SelectEvents: [ simulate ]

--- a/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
@@ -5,8 +5,8 @@
 # V1.0
 #
 
-#include "supernova_g4_dune10kt_1x2x6.fcl"
 #include "larg4particlefilter_dune.fcl"
+#include "supernova_g4_dune10kt_1x2x6.fcl"
 
 
 #Define the neutron filter

--- a/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/supernova_neutronfilter_g4_dune10kt_1x2x6.fcl
@@ -13,7 +13,7 @@
 physics.filters.neutronfilter:  @local::dunefd_neutrontpcfilter
 
 #Run neutron filter at the end
-physics.simulate:  [ @sequence:: physics.simulate, neutronfilter ]
+physics.simulate:  [ @sequence::physics.simulate, neutronfilter ]
 
 #Tell ART to actually filter using the ART filter
 outputs.out1.SelectEvents: [ neutronfilter ]


### PR DESCRIPTION
This PR creates an amended supernova g4 workflow for the HD 1x2x6, and selects only events in which there is a neutron with TPC activity.
The PR relies on the fcl config defined in: https://github.com/DUNE/dunesim/pull/64