### PR TITLE
reduce memory for detsim stage1

### DIFF
--- a/fcl/protodunehd/detsim/standard_detsim_protodunehd_stage1.fcl
+++ b/fcl/protodunehd/detsim/standard_detsim_protodunehd_stage1.fcl
@@ -1,5 +1,15 @@
 #include "standard_detsim_protodunehd.fcl"
 process_name: DetsimStage1
 
+# minimum services for wirecell tpc simulation
+services:
+{
+  TimeTracker:       @local::dune_time_tracker
+  MemoryTracker:     @local::dune_memory_tracker
+  RandomNumberGenerator: {} #ART native random number generator
+  FileCatalogMetadata:  @local::art_file_catalog_mc
+  ExptGeoHelperInterface:       @local::dune_geometry_helper
+}
+
 physics.simulate: [tpcrawdecoder]
 outputs.out1.fileName: "%ifb_detsim_stage1.root"


### PR DESCRIPTION
This PR removes unused services for detsim stage1 (wirecell TPC simulation), as a result, the memory usage is significantly reduced:
<img width="741" alt="image" src="https://github.com/DUNE/dunesw/assets/10663117/9493b59d-5256-465e-b3c5-262a1cb0d543">

Here are the commands for my test up to the detsim stage1:
```
source /cvmfs/dune.opensciencegrid.org/products/dune/setup_dune.sh;
setup dunesw v09_85_00d00 -q e26:prof

lar -n1 -c prod_cosmics_1GeV_protodunehd.fcl -o gen.root
lar -n1 -c standard_g4_protodunehd_stage1.fcl gen.root -o g4a.root
lar -n1 -c standard_g4_protodunehd_stage2.fcl g4a.root -o g4b.root
lar -n 1 -c standard_detsim_protodunehd_stage1.fcl g4b.root -o detsim1.root # only tpcrawdecoder
```

Just for a sanity check, here are the waveforms from the simulation (all look good):
<img width="535" alt="image" src="https://github.com/DUNE/dunesw/assets/10663117/ab19d807-5a83-4c56-b301-3fbe334544c5">
