### PR TITLE
PDVD fix cosmics simulation window

### DIFF
--- a/fcl/protodunevd/g4/protodunevd_refactored_g4_stage2.fcl
+++ b/fcl/protodunevd/g4/protodunevd_refactored_g4_stage2.fcl
@@ -26,16 +26,13 @@ source:
   fileNames: ["g4_stage1_protoDUNE.root"]
 }
 
-protodunevd_ionandscint_active: @local::protodunevd_ionandscint
-protodunevd_ionandscint_active.Instances:    "LArG4DetectorServicevolTPCActive"
-
 physics:
 {
 
   producers:
   {
     rns: {module_type: "RandomNumberSaver"}
-    IonAndScint:  @local::protodunevd_ionandscint_active
+    IonAndScint:  @local::protodunevd_ionandscint
     #PDFastSim:    @local::protodune_pdfastsim_pvs
   }
 

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics.fcl
@@ -71,3 +71,6 @@ outputs:
 services.TFileService.fileName: "gen_protodunevd_cosmics_hist.root"
 source.maxEvents: 1
 outputs.out1.fileName: "gen_protodunevd_cosmics.root"
+
+physics.producers.cosmicgenerator.SampleTime: 6.0e-3
+physics.producers.cosmicgenerator.TimeOffset: -3.0e-3

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio.fcl
@@ -75,3 +75,6 @@ outputs:
 services.TFileService.fileName: "gen_protodunevd_cosmics_radio_hist.root"
 source.maxEvents: 1
 outputs.out1.fileName: "gen_protodunevd_cosmics_radio.root"
+
+physics.producers.cosmicgenerator.SampleTime: 6.0e-3
+physics.producers.cosmicgenerator.TimeOffset: -3.0e-3

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_electron_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_electron_1GeV.fcl
@@ -78,3 +78,5 @@ services.TFileService.fileName: "gen_protodunevd_cosmics_radio_electron_1GeV_his
 source.maxEvents: 1
 outputs.out1.fileName: "gen_protodunevd_cosmics_radio_electron_1GeV.root"
 
+physics.producers.cosmicgenerator.SampleTime: 6.0e-3
+physics.producers.cosmicgenerator.TimeOffset: -3.0e-3

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_kaon_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_kaon_1GeV.fcl
@@ -78,3 +78,5 @@ services.TFileService.fileName: "gen_protodunevd_cosmics_radio_kaon_1GeV_hist.ro
 source.maxEvents: 1
 outputs.out1.fileName: "gen_protodunevd_cosmics_radio_kaon_1GeV.root"
 
+physics.producers.cosmicgenerator.SampleTime: 6.0e-3
+physics.producers.cosmicgenerator.TimeOffset: -3.0e-3

--- a/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_pion_1GeV.fcl
+++ b/fcl/protodunevd/gen/gen_protodunevd_cosmics_radio_pion_1GeV.fcl
@@ -80,3 +80,5 @@ services.TFileService.fileName: "gen_protodunevd_cosmics_radio_pion_1GeV_hist.ro
 source.maxEvents: 1
 outputs.out1.fileName: "gen_protodunevd_cosmics_radio_pion_1GeV.root"
 
+physics.producers.cosmicgenerator.SampleTime: 6.0e-3
+physics.producers.cosmicgenerator.TimeOffset: -3.0e-3


### PR DESCRIPTION
The cosmics generator sample time remained set to 4 ms while the readout window is currently 3 ms.
This generates lots of logs from PDS simulation due to photons generated after the 3 ms window:
```
%MSG-w WaveformDigitizerSim:  WaveformDigitizerSim:opdigi@BeginModule  06-Mar-2024 18:15:43 CET run: 1 subRun: 0 event: 1
Skipping a photon at 3798.43 us, outside digitization window of -3005 to 3005
%MSG
```
This is fixed at generator configuration level by setting:
```
physics.producers.cosmicgenerator.SampleTime: 6.0e-3
physics.producers.cosmicgenerator.TimeOffset: -3.0e-3
```
instead of 
```
physics.producers.cosmicgenerator.SampleTime: 8.0e-3
physics.producers.cosmicgenerator.TimeOffset: -4.0e-3
```

In addition, I remove the temporary g4 stage2 fix, I added some time ago to solve a breaking of the sim/reco chain, for deposits that happened outside the active volume.