### PR TITLE
Remove problematic trajcluster from workflow. Add more energyrec products

### DIFF
--- a/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
+++ b/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
@@ -71,6 +71,8 @@ dunefd_horizdrift_producers:
   cvneva:                @local::dunehd_1x2x6_FHC_cvnevaluator
   #neutrino energy reco
   energyrecnumu:        @local::dunefd_nuenergyreco_pandora_numu
+  energyrecnumurange:   @local::dunefd_nuenergyreco_pandora_numu_range
+  energyrecnumumcs:     @local::dunefd_nuenergyreco_pandora_numu_mcs
   energyrecnue:          @local::dunefd_nuenergyreco_pandora_nue
   energyrecnc:           @local::dunefd_nuenergyreco_pandora_nc
   #angle reco configuration
@@ -153,7 +155,9 @@ dunefd_horizdrift_nuenergy:
 [
     energyrecnumu,
     energyrecnue,
-    energyrecnc
+    energyrecnc,
+    energyrecnumurange,
+    energyrecnumumcs
 ]
 
 dunefd_horizdrift_pd_reco1:
@@ -176,11 +180,13 @@ dunefd_horizdrift_workflow_reco1:
 
 dunefd_horizdrift_workflow_reco2:
 [
-    @sequence::dunefd_horizdrift_2dclustering,
+    # All the workflows depending on trajcluster have been disabled until the following issue
+    # gets solved: https://cdcvs.fnal.gov/redmine/issues/28517
+#   @sequence::dunefd_horizdrift_2dclustering,
     @sequence::dunefd_horizdrift_pandora,
-    @sequence::dunefd_horizdrift_pmtrack,
-    @sequence::dunefd_horizdrift_pmtrack_trajcluster,
-    @sequence::dunefd_horizdrift_pmtrack_trajcluster_pfp,
+#   @sequence::dunefd_horizdrift_pmtrack,
+#   @sequence::dunefd_horizdrift_pmtrack_trajcluster,
+#   @sequence::dunefd_horizdrift_pmtrack_trajcluster_pfp,
 #    @sequence::dunefd_horizdrift_pmtrack_showers,
     @sequence::dunefd_horizdrift_cvn,
     @sequence::dunefd_horizdrift_nuenergy,


### PR DESCRIPTION
Removing trajcluster and all the products depending on it until the following issue has not been resolved: https://cdcvs.fnal.gov/redmine/issues/28517
Adding specific energy reco products forcing the use of mcs and by range muon momentum estimations.

Depends on https://github.com/DUNE/dunereco/pull/101