### PR TITLE
Make the 1x2x6 EVD service use the refactored geometry

### DIFF
--- a/fcl/evd/evdservices_dune.fcl
+++ b/fcl/evd/evdservices_dune.fcl
@@ -81,7 +81,7 @@ dunefd45deg_disp:            @local::dunefd_disp
 dunefd45deg_disp.Geometry:   @local::dune10kt_45deg_workspace_geo
 
 dune10kt_1x2x6_disp:       @local::dunefd_disp
-dune10kt_1x2x6_disp.Geometry:   @local::dune10kt_1x2x6_geo
+dune10kt_1x2x6_disp.Geometry:   @local::dune10kt_1x2x6_refactored_geo
 
 dune10kt_3mmpitch_1x2x6_disp:            @local::dunefd_disp
 dune10kt_3mmpitch_1x2x6_disp.Geometry:   @local::dune10kt_3mmpitch_1x2x6_geo
@@ -110,9 +110,6 @@ dune10kt_45deg_1x2x6_disp.Geometry:   @local::dune10kt_45deg_1x2x6_geo
 
 dune10kt_disp:             @local::dunefd_disp
 dune10kt_disp.Geometry:    @local::dune10kt_geo 
-
-dune10kt_1x2x6_disp:             @local::dune10kt_disp
-dune10kt_1x2x6_disp.Geometry:    @local::dune10kt_1x2x6_geo 
 
 dunevd10kt_disp:             @local::dunefd_disp
 dunevd10kt_disp.Geometry:    @local::dunevd10kt_geo 


### PR DESCRIPTION
As reported by @linyan-w on slack, the 1x2x6 evd points to the non-refactored geometry.

This PR:
 - Makes the 1x2x6 EVD service use the refactored 1x2x6 geometry
 - Removes a spurious 1x2x6 service block that was overriding my fix
 
 Here is a fcl dump diff before/after the fix:
 
 ```
 [dunegpvm06.fnal.gov@evdGeom]$ diff lar.txt larFix.txt
178,180c178,180
<       GDML: "dune10kt_v4_1x2x6.gdml"
<       Name: "dune10kt_v4_1x2x6"
<       ROOT: "dune10kt_v4_1x2x6.gdml"
---
>       GDML: "dune10kt_v6_refactored_1x2x6.gdml"
>       Name: "dune10kt_v6_1x2x6"
>       ROOT: "dune10kt_v6_refactored_1x2x6.gdml"
875c875
<          fileName: "lar.txt"
---
>          fileName: "larFix.txt"
```