### PR TITLE
Adding trajcluster back to the worflow

### DIFF
--- a/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
+++ b/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
@@ -180,14 +180,12 @@ dunefd_horizdrift_workflow_reco1:
 
 dunefd_horizdrift_workflow_reco2:
 [
-    # All the workflows depending on trajcluster have been disabled until the following issue
-    # gets solved: https://cdcvs.fnal.gov/redmine/issues/28517
-#   @sequence::dunefd_horizdrift_2dclustering,
+    @sequence::dunefd_horizdrift_2dclustering,
     @sequence::dunefd_horizdrift_pandora,
-#   @sequence::dunefd_horizdrift_pmtrack,
-#   @sequence::dunefd_horizdrift_pmtrack_trajcluster,
-#   @sequence::dunefd_horizdrift_pmtrack_trajcluster_pfp,
-#    @sequence::dunefd_horizdrift_pmtrack_showers,
+    @sequence::dunefd_horizdrift_pmtrack,
+    @sequence::dunefd_horizdrift_pmtrack_trajcluster,
+    @sequence::dunefd_horizdrift_pmtrack_trajcluster_pfp,
+    @sequence::dunefd_horizdrift_pmtrack_showers,
     @sequence::dunefd_horizdrift_cvn,
     @sequence::dunefd_horizdrift_nuenergy,
     @sequence::dunefd_horizdrift_pd_reco1,


### PR DESCRIPTION
Adding back trajcluster and all the subsequent modules to the default workflow now that the issue https://cdcvs.fnal.gov/redmine/issues/28517 has been solved in [larsoft v09_90_00](https://github.com/LArSoft/larsoft/releases/tag/v09_90_00)