### PR TITLE
Adding fcls for CAFMaker

### DIFF
--- a/fcl/dunefd/caf/cafmaker_atmos_dune10kt_1x2x6_runreco-nuenergy-nuangular.fcl
+++ b/fcl/dunefd/caf/cafmaker_atmos_dune10kt_1x2x6_runreco-nuenergy-nuangular.fcl
@@ -1,0 +1,8 @@
+#include "cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl"
+
+physics.analyzers.cafmaker.IsAtmoCVN: true
+
+physics.prod: [
+    @sequence::dunefd_hd_ereco,
+    @sequence::dunefd_hd_anglereco
+]

--- a/fcl/dunefd/caf/cafmaker_atmos_dune10kt_1x2x6_runreco-nuenergy-nuangular_geov5.fcl
+++ b/fcl/dunefd/caf/cafmaker_atmos_dune10kt_1x2x6_runreco-nuenergy-nuangular_geov5.fcl
@@ -1,0 +1,3 @@
+#include "cafmaker_atmos_dune10kt_1x2x6_runreco-nuenergy-nuangular.fcl"
+
+services.Geometry:   @local::dune10kt_1x2x6_v5_refactored_geo

--- a/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl
+++ b/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl
@@ -43,24 +43,3 @@ physics.prod: [
 ]
 
 physics.trigger_paths: [ prod ] 
-
-
-physics.producers.energyrecnumu.HitLabel: "hitfd"
-physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumu.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnumurange.HitLabel: "hitfd"
-physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumurange.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnumumcs.HitLabel: "hitfd"
-physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumumcs.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnue.HitLabel: "hitfd"
-physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnue.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnc.HitLabel: "hitfd"
-physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnc.HitToSpacePointLabel: "hitfd"

--- a/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl
+++ b/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl
@@ -1,0 +1,66 @@
+#include "energyreco.fcl"
+#include "angularreco.fcl"
+#include "standard_cafmaker_dune10kt_1x2x6.fcl"
+
+dunefd_hd_producers:
+{
+    #neutrino energy reco
+    energyrecnumu:      @local::dunefd_nuenergyreco_pandora_numu
+    energyrecnumurange: @local::dunefd_nuenergyreco_pandora_numu_range
+    energyrecnumumcs:   @local::dunefd_nuenergyreco_pandora_numu_mcs
+    energyrecnue:       @local::dunefd_nuenergyreco_pandora_nue
+    energyrecnc:        @local::dunefd_nuenergyreco_pandora_nc
+    #angle reco configuration
+    anglereconue:       @local::dunefd_nuangularreco_pandora_nue
+    anglereconumu:      @local::dunefd_nuangularreco_pandora_numu
+    anglereconuepfps:   @local::dunefd_nuangularreco_pandora_nue_allpfps
+    anglereconumupfps:  @local::dunefd_nuangularreco_pandora_numu_allpfps
+}
+
+dunefd_hd_ereco:
+[
+    energyrecnumu,
+    energyrecnumurange,
+    energyrecnumumcs,
+    energyrecnue,
+    energyrecnc
+]
+
+dunefd_hd_anglereco:
+[
+    anglereconue,
+    anglereconumu,
+    anglereconuepfps,
+    anglereconumupfps
+]
+
+physics.producers: {
+    @table::dunefd_hd_producers
+}
+
+physics.prod: [
+    @sequence::dunefd_hd_ereco
+]
+
+physics.trigger_paths: [ prod ] 
+
+
+physics.producers.energyrecnumu.HitLabel: "hitfd"
+physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumu.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnumurange.HitLabel: "hitfd"
+physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumurange.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnumumcs.HitLabel: "hitfd"
+physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumumcs.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnue.HitLabel: "hitfd"
+physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnue.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnc.HitLabel: "hitfd"
+physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnc.HitToSpacePointLabel: "hitfd"

--- a/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy_geov5.fcl
+++ b/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy_geov5.fcl
@@ -1,0 +1,3 @@
+#include "cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl"
+
+services.Geometry:   @local::dune10kt_1x2x6_v5_refactored_geo

--- a/fcl/dunefd/caf/standard_cafmaker_atmos_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_atmos_dune10kt_1x2x6.fcl
@@ -1,0 +1,8 @@
+#include "standard_cafmaker_dune10kt_1x2x6.fcl"
+
+physics.analyzers.cafmaker.IsAtmoCVN: true
+
+physics.prod: [
+    @sequence::dunefd_hd_ereco,
+    @sequence::dunefd_hd_anglereco
+]

--- a/fcl/dunefd/caf/standard_cafmaker_atmos_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_atmos_dune10kt_1x2x6.fcl
@@ -1,8 +1,3 @@
 #include "standard_cafmaker_dune10kt_1x2x6.fcl"
 
 physics.analyzers.cafmaker.IsAtmoCVN: true
-
-physics.prod: [
-    @sequence::dunefd_hd_ereco,
-    @sequence::dunefd_hd_anglereco
-]

--- a/fcl/dunefd/caf/standard_cafmaker_atmos_dune10kt_1x2x6_geov5.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_atmos_dune10kt_1x2x6_geov5.fcl
@@ -1,0 +1,3 @@
+#include "standard_cafmaker_atmos_dune10kt_1x2x6.fcl"
+
+services.Geometry:   @local::dune10kt_1x2x6_v5_refactored_geo

--- a/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
@@ -1,19 +1,15 @@
 #include "services_dune.fcl"
 #include "mvamodule.fcl"
 #include "CAFMaker.fcl"
+#include "tools_dune.fcl"
 
 process_name: CafMaker
 
 services:
 {
+  @table::dunefd_1x2x6_reco_services
   # Load the service that manages root files for histograms where the CAF info will be saved.
   TFileService: { fileName: "caf.root" }
-  TimeTracker:       {}
-  RandomNumberGenerator: {}
-  MemoryTracker:         {}
-  message:      @local::dune_message_services_prod_debug #TODO: Change for prod
-  FileCatalogMetadata:  @local::art_file_catalog_mc
-  @table::dunefd_simulation_services
 }
 
 source:

--- a/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
@@ -2,9 +2,6 @@
 #include "mvamodule.fcl"
 #include "CAFMaker.fcl"
 
-#include "energyreco.fcl"
-#include "angularreco.fcl"
-
 process_name: CafMaker
 
 services:
@@ -25,38 +22,6 @@ source:
   maxEvents:  -1        # Number of events to create
 }
 
-dunefd_hd_producers:
-{
-    #neutrino energy reco
-    energyrecnumu:      @local::dunefd_nuenergyreco_pandora_numu
-    energyrecnumurange: @local::dunefd_nuenergyreco_pandora_numu_range
-    energyrecnumumcs:   @local::dunefd_nuenergyreco_pandora_numu_mcs
-    energyrecnue:       @local::dunefd_nuenergyreco_pandora_nue
-    energyrecnc:        @local::dunefd_nuenergyreco_pandora_nc
-    #angle reco configuration
-    anglereconue:       @local::dunefd_nuangularreco_pandora_nue
-    anglereconumu:      @local::dunefd_nuangularreco_pandora_numu
-    anglereconuepfps:   @local::dunefd_nuangularreco_pandora_nue_allpfps
-    anglereconumupfps:  @local::dunefd_nuangularreco_pandora_numu_allpfps
-}
-
-dunefd_hd_ereco:
-[
-    energyrecnumu,
-    energyrecnumurange,
-    energyrecnumumcs,
-    energyrecnue,
-    energyrecnc
-]
-
-dunefd_hd_anglereco:
-[
-    anglereconue,
-    anglereconumu,
-    anglereconuepfps,
-    anglereconumupfps
-]
-
 # Define and configure some modules to do work on each event.
 # First modules are defined; they are scheduled later.
 # Modules are grouped by type.
@@ -64,7 +29,6 @@ physics:
 {
 
  producers:{
-    @table::dunefd_hd_producers
  }
 
  analyzers:
@@ -72,37 +36,11 @@ physics:
  cafmaker:          @local::dunefd_cafmaker
 }
 
-
- #define the producer and filter modules for this path, order matters, 
- #filters reject all following items.  see lines starting physics.producers below
- prod: [
-    @sequence::dunefd_hd_ereco
-]
  caf:  [ cafmaker]
- trigger_paths: [ prod ] 
+ trigger_paths: [ ] 
 
  #end_paths is a keyword and contains the paths that do not modify the art::Event, 
  #ie analyzers and output streams.  these all run simultaneously
  end_paths:     [ caf ]  
 
 }
-
-physics.producers.energyrecnumu.HitLabel: "hitfd"
-physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumu.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnumurange.HitLabel: "hitfd"
-physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumurange.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnumumcs.HitLabel: "hitfd"
-physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumumcs.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnue.HitLabel: "hitfd"
-physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnue.HitToSpacePointLabel: "hitfd"
-
-physics.producers.energyrecnc.HitLabel: "hitfd"
-physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnc.HitToSpacePointLabel: "hitfd"

--- a/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
@@ -1,0 +1,108 @@
+#include "services_dune.fcl"
+#include "mvamodule.fcl"
+#include "CAFMaker.fcl"
+
+#include "energyreco.fcl"
+#include "angularreco.fcl"
+
+process_name: CafMaker
+
+services:
+{
+  # Load the service that manages root files for histograms where the CAF info will be saved.
+  TFileService: { fileName: "caf.root" }
+  TimeTracker:       {}
+  RandomNumberGenerator: {}
+  MemoryTracker:         {}
+  message:      @local::dune_message_services_prod_debug #TODO: Change for prod
+  FileCatalogMetadata:  @local::art_file_catalog_mc
+  @table::dunefd_simulation_services
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:  -1        # Number of events to create
+}
+
+dunefd_hd_producers:
+{
+    #neutrino energy reco
+    energyrecnumu:      @local::dunefd_nuenergyreco_pandora_numu
+    energyrecnumurange: @local::dunefd_nuenergyreco_pandora_numu_range
+    energyrecnumumcs:   @local::dunefd_nuenergyreco_pandora_numu_mcs
+    energyrecnue:       @local::dunefd_nuenergyreco_pandora_nue
+    energyrecnc:        @local::dunefd_nuenergyreco_pandora_nc
+    #angle reco configuration
+    anglereconue:       @local::dunefd_nuangularreco_pandora_nue
+    anglereconumu:      @local::dunefd_nuangularreco_pandora_numu
+    anglereconuepfps:   @local::dunefd_nuangularreco_pandora_nue_allpfps
+    anglereconumupfps:  @local::dunefd_nuangularreco_pandora_numu_allpfps
+}
+
+dunefd_hd_ereco:
+[
+    energyrecnumu,
+    energyrecnumurange,
+    energyrecnumumcs,
+    energyrecnue,
+    energyrecnc
+]
+
+dunefd_hd_anglereco:
+[
+    anglereconue,
+    anglereconumu,
+    anglereconuepfps,
+    anglereconumupfps
+]
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+
+ producers:{
+    @table::dunefd_hd_producers
+ }
+
+ analyzers:
+{
+ cafmaker:          @local::dunefd_cafmaker
+}
+
+
+ #define the producer and filter modules for this path, order matters, 
+ #filters reject all following items.  see lines starting physics.producers below
+ prod: [
+    @sequence::dunefd_hd_ereco
+]
+ caf:  [ cafmaker]
+ trigger_paths: [ prod ] 
+
+ #end_paths is a keyword and contains the paths that do not modify the art::Event, 
+ #ie analyzers and output streams.  these all run simultaneously
+ end_paths:     [ caf ]  
+
+}
+
+physics.producers.energyrecnumu.HitLabel: "hitfd"
+physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumu.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnumurange.HitLabel: "hitfd"
+physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumurange.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnumumcs.HitLabel: "hitfd"
+physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumumcs.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnue.HitLabel: "hitfd"
+physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnue.HitToSpacePointLabel: "hitfd"
+
+physics.producers.energyrecnc.HitLabel: "hitfd"
+physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnc.HitToSpacePointLabel: "hitfd"

--- a/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6_geov5.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6_geov5.fcl
@@ -1,0 +1,3 @@
+#include "standard_cafmaker_dune10kt_1x2x6.fcl"
+
+services.Geometry:   @local::dune10kt_1x2x6_v5_refactored_geo

--- a/fcl/dunefdvd/caf/cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy.fcl
+++ b/fcl/dunefdvd/caf/cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy.fcl
@@ -1,0 +1,28 @@
+#include "cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl"
+#include "tools_dune.fcl"
+
+services: {
+    @table::services
+    @table::dunefdvd_reco_services
+    @table::dunefdvd_1x8x6_3view_30deg_reco_services
+}
+
+physics.producers.energyrecnumu.HitLabel: "gaushit"
+physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumu.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnumurange.HitLabel: "gaushit"
+physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumurange.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnumumcs.HitLabel: "gaushit"
+physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumumcs.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnue.HitLabel: "gaushit"
+physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnue.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnc.HitLabel: "gaushit"
+physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnc.HitToSpacePointLabel: "pandora"

--- a/fcl/dunefdvd/caf/cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy.fcl
+++ b/fcl/dunefdvd/caf/cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy.fcl
@@ -1,28 +1,32 @@
+#include "energyreco.fcl"
 #include "cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl"
 #include "tools_dune.fcl"
 
-services: {
-    @table::services
-    @table::dunefdvd_reco_services
-    @table::dunefdvd_1x8x6_3view_30deg_reco_services
+dunefd_vd_30deg_producers:
+{
+    #neutrino energy reco
+    energyrecnumu:      @local::dunefdvd_30deg_nuenergyreco_pandora_numu
+    energyrecnumurange: @local::dunefdvd_30deg_nuenergyreco_pandora_numu_range
+    energyrecnumumcs:   @local::dunefdvd_30deg_nuenergyreco_pandora_numu_mcs
+    energyrecnue:       @local::dunefdvd_30deg_nuenergyreco_pandora_nue
+    energyrecnc:        @local::dunefdvd_30deg_nuenergyreco_pandora_nc
 }
 
-physics.producers.energyrecnumu.HitLabel: "gaushit"
-physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumu.HitToSpacePointLabel: "pandora"
+dunefd_vd_30deg_ereco:
+[
+    energyrecnumu,
+    energyrecnumurange,
+    energyrecnumumcs,
+    energyrecnue,
+    energyrecnc
+]
 
-physics.producers.energyrecnumurange.HitLabel: "gaushit"
-physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumurange.HitToSpacePointLabel: "pandora"
+physics.producers: {
+    @table::dunefd_vd_30deg_producers
+}
 
-physics.producers.energyrecnumumcs.HitLabel: "gaushit"
-physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumumcs.HitToSpacePointLabel: "pandora"
+physics.prod: [
+    @sequence::dunefd_vd_30deg_ereco
+]
 
-physics.producers.energyrecnue.HitLabel: "gaushit"
-physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnue.HitToSpacePointLabel: "pandora"
-
-physics.producers.energyrecnc.HitLabel: "gaushit"
-physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnc.HitToSpacePointLabel: "pandora"
+physics.trigger_paths: [ prod ] 

--- a/fcl/dunefdvd/caf/cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy_geov3.fcl
+++ b/fcl/dunefdvd/caf/cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy_geov3.fcl
@@ -1,0 +1,3 @@
+#include "cafmaker_dunevd10kt_1x8x6_3view_30deg_runreco-nuenergy.fcl"
+
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo

--- a/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -1,8 +1,43 @@
-#include "standard_cafmaker_dune10kt_1x2x6.fcl"
+#include "services_dune.fcl"
+#include "mvamodule.fcl"
+#include "CAFMaker.fcl"
 #include "tools_dune.fcl"
 
-services: {
-    @table::services
-    @table::dunefdvd_reco_services
-    @table::dunefdvd_1x8x6_3view_30deg_reco_services
+
+process_name: CafMaker
+
+services:
+{
+  @table::dunefdvd_1x8x6_3view_30deg_reco_services
+  # Load the service that manages root files for histograms where the CAF info will be saved.
+  TFileService: { fileName: "caf.root" }
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:  -1        # Number of events to create
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+
+ producers:{
+ }
+
+ analyzers:
+{
+ cafmaker:          @local::dunefd_cafmaker
+}
+
+ caf:  [ cafmaker]
+ trigger_paths: [ ] 
+
+ #end_paths is a keyword and contains the paths that do not modify the art::Event, 
+ #ie analyzers and output streams.  these all run simultaneously
+ end_paths:     [ caf ]  
+
 }

--- a/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -6,23 +6,3 @@ services: {
     @table::dunefdvd_reco_services
     @table::dunefdvd_1x8x6_3view_30deg_reco_services
 }
-
-physics.producers.energyrecnumu.HitLabel: "gaushit"
-physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumu.HitToSpacePointLabel: "pandora"
-
-physics.producers.energyrecnumurange.HitLabel: "gaushit"
-physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumurange.HitToSpacePointLabel: "pandora"
-
-physics.producers.energyrecnumumcs.HitLabel: "gaushit"
-physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnumumcs.HitToSpacePointLabel: "pandora"
-
-physics.producers.energyrecnue.HitLabel: "gaushit"
-physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnue.HitToSpacePointLabel: "pandora"
-
-physics.producers.energyrecnc.HitLabel: "gaushit"
-physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
-physics.producers.energyrecnc.HitToSpacePointLabel: "pandora"

--- a/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -1,0 +1,28 @@
+#include "standard_cafmaker_dune10kt_1x2x6.fcl"
+#include "tools_dune.fcl"
+
+services: {
+    @table::services
+    @table::dunefdvd_reco_services
+    @table::dunefdvd_1x8x6_3view_30deg_reco_services
+}
+
+physics.producers.energyrecnumu.HitLabel: "gaushit"
+physics.producers.energyrecnumu.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumu.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnumurange.HitLabel: "gaushit"
+physics.producers.energyrecnumurange.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumurange.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnumumcs.HitLabel: "gaushit"
+physics.producers.energyrecnumumcs.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnumumcs.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnue.HitLabel: "gaushit"
+physics.producers.energyrecnue.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnue.HitToSpacePointLabel: "pandora"
+
+physics.producers.energyrecnc.HitLabel: "gaushit"
+physics.producers.energyrecnc.WireLabel: "tpcrawdecoder:gauss"
+physics.producers.energyrecnc.HitToSpacePointLabel: "pandora"

--- a/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg_geov3.fcl
+++ b/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg_geov3.fcl
@@ -1,0 +1,3 @@
+#include "standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl"
+
+services.Geometry: @local::dunevd10kt_1x8x6_3view_30deg_v3_geo


### PR DESCRIPTION
Adding several fcls files to run the FD CAFMaker module.
Energy and angle reconstruction are recomputed to allow for an easy integration of reco improvements.