### PR TITLE
FD1-HD 10kt workflow for LBL

### DIFF
--- a/fcl/dunefd/detsim/detsim_1dsimulation_dune10kt.fcl
+++ b/fcl/dunefd/detsim/detsim_1dsimulation_dune10kt.fcl
@@ -1,0 +1,29 @@
+#include "standard_detsim_dune10kt.fcl"
+
+physics.producers:
+{
+    @table::physics.producers
+    daq:                   @local::dune_detsim
+    tpcrawdecoder:         @erase
+}
+
+physics.simulate[0]: daq #terrible way of changing the running producer from wirecell to the older detsim.  Erasing tpcrawdecoder does provide a small amount of protection against us replacing the wrong array element (as the job will not run)
+
+# Use fixed values instead of DB for pedestals.
+services.DetPedestalService: @local::dune_fixedpeds
+
+# DetSim flags.
+physics.producers.daq.NoiseOn:     true
+physics.producers.daq.PedestalOn:  true
+physics.producers.daq.DistortOn:   false
+physics.producers.daq.SuppressOn:  true
+physics.producers.daq.SimChannelLabel: "elecDrift"
+
+# DetSim services.
+services.SimChannelExtractService: @local::scxgeneric
+services.ChannelNoiseService:      @local::chnoiseold
+services.PedestalAdditionService:  @local::padprovided
+services.AdcDistortService:        @local::stuckbits
+services.AdcSuppressService:       @local::zslegacy
+services.AdcCompressService:       @local::cmpblock
+

--- a/fcl/dunefd/detsim/standard_detsim_dune10kt.fcl
+++ b/fcl/dunefd/detsim/standard_detsim_dune10kt.fcl
@@ -56,32 +56,3 @@ outputs: {
    compressionLevel: 1
  }
 }
-
-# Use fixed values instead of DB for pedestals.
-services.DetPedestalService: @local::dune_fixedpeds
-
-# DetSim flags.
-physics.producers.daq.NoiseOn:     true
-physics.producers.daq.PedestalOn:  true
-physics.producers.daq.DistortOn:   false
-physics.producers.daq.SuppressOn:  true
-
-# DetSim services.
-services.SimChannelExtractService: @local::scxgeneric
-services.ChannelNoiseService:      @local::chnoiseold
-services.PedestalAdditionService:  @local::padprovided
-services.AdcDistortService:        @local::stuckbits
-services.AdcSuppressService:       @local::zslegacy
-services.AdcCompressService:       @local::cmpblock
-
-# Disable bad channels.
-#services.IChannelStatusService.BadChannels: [ ]
-
-### Supernova detsim noise levels ###
-### What value do I want for the Noise Level?
-services.ChannelNoiseService.NoiseNormU:  5.75
-services.ChannelNoiseService.NoiseNormV:  5.75
-services.ChannelNoiseService.NoiseNormZ:  4.5
-
-#configs: ["pgrapher/experiment/pdsp/wcls-sim-drift-simchannel.jsonnet"]
-#=> configs: ["pgrapher/experiment/dune10kt-1x2x6/wcls-sim-drift-simchannel.jsonnet"]

--- a/fcl/dunefd/detsim/standard_detsim_dune10kt.fcl
+++ b/fcl/dunefd/detsim/standard_detsim_dune10kt.fcl
@@ -37,7 +37,7 @@ physics: {
  producers: {
 #   daq:            @local::dune_detsim
 
-   tpcrawdecoder: @local::dune10kt_hd_sim_nfsp
+   tpcrawdecoder: @local::dune10kt_horizdrift_sim_nfsp
    opdigi:        @local::standard_template_digitizer
    rns:            { module_type: "RandomNumberSaver" }
  }

--- a/fcl/dunefd/detsim/standard_detsim_dune10kt.fcl
+++ b/fcl/dunefd/detsim/standard_detsim_dune10kt.fcl
@@ -37,7 +37,7 @@ physics: {
  producers: {
 #   daq:            @local::dune_detsim
 
-   tpcrawdecoder: @local::tpcrawdecoder_dunefd_horizdrift
+   tpcrawdecoder: @local::dune10kt_hd_sim_nfsp
    opdigi:        @local::standard_template_digitizer
    rns:            { module_type: "RandomNumberSaver" }
  }

--- a/fcl/dunefd/gen/genie/prodgenie_anu_dune10kt.fcl
+++ b/fcl/dunefd/gen/genie/prodgenie_anu_dune10kt.fcl
@@ -4,4 +4,4 @@ process_name: GenieGen
 
 outputs.out1.fileName: "prodgenie_anu_dune10kt_gen.root"
 
-physics.producers.generator: @local::dune_fd_genie_anu_simple_flux_workspace_window
+physics.producers.generator: @local:dunefd_10kt_genie_anu_lbnf_dk2nu

--- a/fcl/dunefd/gen/genie/prodgenie_nu_dune10kt.fcl
+++ b/fcl/dunefd/gen/genie/prodgenie_nu_dune10kt.fcl
@@ -4,4 +4,4 @@ process_name: GenieGen
 
 outputs.out1.fileName: "prodgenie_nu_dune10kt_gen.root"
 
-physics.producers.generator: @local::dune_fd_genie_nu_simple_flux_workspace_window
+physics.producers.generator: @local::dunefd_10kt_genie_nu_lbnf_dk2nu

--- a/fcl/dunefd/gen/single/prod_muminus_5.0GeV_20deg_fixedstart_nearendapa_dune10kt.fcl
+++ b/fcl/dunefd/gen/single/prod_muminus_5.0GeV_20deg_fixedstart_nearendapa_dune10kt.fcl
@@ -1,0 +1,26 @@
+#include "prodsingle_common_dunefd.fcl"
+
+process_name: SinglesGen
+
+outputs.out1.fileName: "prod_muminus_5.0GeV_20deg_fixedstart_nearendapa_dune10kt.root"
+
+source.firstRun: 20000014
+
+physics.producers.generator.PDG: [ 13 ]            # mu-
+physics.producers.generator.PosDist: 0             # Flat position dist.
+physics.producers.generator.X0: [ 600. ]
+physics.producers.generator.Y0: [ 0.0 ]
+physics.producers.generator.Z0: [ -10. ]
+physics.producers.generator.T0: [ 0. ]
+physics.producers.generator.SigmaX: [ 0.0 ]      # x = (-3.6, 3.6)
+physics.producers.generator.SigmaY: [ 100 ]      # y = (-6, 6)
+physics.producers.generator.SigmaZ: [ 0.0 ]      # z = (0, 13.9)
+physics.producers.generator.SigmaT: [ 0.0 ]        # In time
+physics.producers.generator.PDist: 0               # Flat momentum dist. (0.1-2.0 GeV)
+physics.producers.generator.P0: [ 5.0 ]
+physics.producers.generator.SigmaP: [ 0.0 ]
+physics.producers.generator.AngleDist: 0           # Flat angle dist.
+physics.producers.generator.Theta0XZ: [ -20. ]       # y-azimuth
+physics.producers.generator.Theta0YZ: [ 5. ]       # y-latitude
+physics.producers.generator.SigmaThetaXZ: [ 0.0 ] # Quasi-isotropic
+physics.producers.generator.SigmaThetaYZ: [ 0.0 ]

--- a/fcl/dunefd/gen/single/prod_muminus_5.0GeV_45deg_fixedstart_dune10kt.fcl
+++ b/fcl/dunefd/gen/single/prod_muminus_5.0GeV_45deg_fixedstart_dune10kt.fcl
@@ -2,7 +2,7 @@
 
 process_name: SinglesGen
 
-outputs.out1.fileName: "prod_muminus_5.0GeV_45deg_fixedstart_dune10kt_1x2x6.root"
+outputs.out1.fileName: "prod_muminus_5.0GeV_45deg_fixedstart_dune10kt.root"
 
 source.firstRun: 20000014
 

--- a/fcl/dunefd/gen/single/prod_muminus_5.0GeV_45deg_fixedstart_dune10kt.fcl
+++ b/fcl/dunefd/gen/single/prod_muminus_5.0GeV_45deg_fixedstart_dune10kt.fcl
@@ -1,0 +1,26 @@
+#include "prodsingle_common_dunefd.fcl"
+
+process_name: SinglesGen
+
+outputs.out1.fileName: "prod_muminus_5.0GeV_45deg_fixedstart_dune10kt_1x2x6.root"
+
+source.firstRun: 20000014
+
+physics.producers.generator.PDG: [ 13 ]            # mu-
+physics.producers.generator.PosDist: 0             # Flat position dist.
+physics.producers.generator.X0: [ 0.0 ]
+physics.producers.generator.Y0: [ 0.0 ]
+physics.producers.generator.Z0: [ -10. ]
+physics.producers.generator.T0: [ 0. ]
+physics.producers.generator.SigmaX: [ 0.0 ]      # x = (-3.6, 3.6)
+physics.producers.generator.SigmaY: [ 100 ]      # y = (-6, 6)
+physics.producers.generator.SigmaZ: [ 0.0 ]      # z = (0, 13.9)
+physics.producers.generator.SigmaT: [ 0.0 ]        # In time
+physics.producers.generator.PDist: 0               # Flat momentum dist. (0.1-2.0 GeV)
+physics.producers.generator.P0: [ 5.0 ]
+physics.producers.generator.SigmaP: [ 0.0 ]
+physics.producers.generator.AngleDist: 0           # Flat angle dist.
+physics.producers.generator.Theta0XZ: [ 45. ]       # y-azimuth
+physics.producers.generator.Theta0YZ: [ 0. ]       # y-latitude
+physics.producers.generator.SigmaThetaXZ: [ 0.0 ] # Quasi-isotropic
+physics.producers.generator.SigmaThetaYZ: [ 0.0 ]

--- a/fcl/dunefd/reco/reco1_1dsignalprocessing_dune10kt.fcl
+++ b/fcl/dunefd/reco/reco1_1dsignalprocessing_dune10kt.fcl
@@ -1,0 +1,5 @@
+#include "standard_reco1_dune10kt.fcl"
+
+physics.reco: [ caldata, @sequence::physics.reco ]
+
+physics.producers.gaushit.CalDataModuleLabel: "caldata"

--- a/fcl/dunefd/reco/reco2_1dsignalprocessing_dune10kt.fcl
+++ b/fcl/dunefd/reco/reco2_1dsignalprocessing_dune10kt.fcl
@@ -1,0 +1,5 @@
+#include "standard_reco2_dune10kt.fcl"
+
+services.BackTrackerService.BackTracker.SimChannelModuleLabel: "elecDrift"
+physics.producers.pandora.SimChannelModuleLabel: "elecDrift"
+

--- a/fcl/dunefd/reco/reco2_1dsignalprocessing_dune10kt.fcl
+++ b/fcl/dunefd/reco/reco2_1dsignalprocessing_dune10kt.fcl
@@ -1,5 +1,12 @@
 #include "standard_reco2_dune10kt.fcl"
 
 services.BackTrackerService.BackTracker.SimChannelModuleLabel: "elecDrift"
+
 physics.producers.pandora.SimChannelModuleLabel: "elecDrift"
+physics.producers.pmtrack.WireModuleLabel:    "caldata"
+physics.producers.pmtracktc.WireModuleLabel:  "caldata"
+physics.producers.emtrkmichelid.WireLabel:    "caldata"
+physics.producers.energyrecnumu.WireLabel:    "caldata"
+physics.producers.energyrecnue.WireLabel:     "caldata"
+physics.producers.energyrecnc.WireLabel:      "caldata"
 

--- a/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
+++ b/fcl/dunefd/reco/workflow_reco_dune10kt.fcl
@@ -188,12 +188,12 @@ dunefd_horizdrift_workflow_reco1:
 
 dunefd_horizdrift_workflow_reco2:
 [
-    @sequence::dunefd_horizdrift_2dclustering,
+#@sequence::dunefd_horizdrift_2dclustering,
     @sequence::dunefd_horizdrift_pandora,
-    @sequence::dunefd_horizdrift_pmtrack,
-    @sequence::dunefd_horizdrift_pmtrack_trajcluster,
-    @sequence::dunefd_horizdrift_pmtrack_trajcluster_pfp,
-    @sequence::dunefd_horizdrift_pmtrack_showers,
+    #@sequence::dunefd_horizdrift_pmtrack,
+#@sequence::dunefd_horizdrift_pmtrack_trajcluster,
+#@sequence::dunefd_horizdrift_pmtrack_trajcluster_pfp,
+#@sequence::dunefd_horizdrift_pmtrack_showers,
     @sequence::dunefd_horizdrift_cvn,
     @sequence::dunefd_horizdrift_nuenergy,
     @sequence::dunefd_horizdrift_pd_reco1,


### PR DESCRIPTION
This PR relies on
 - https://github.com/DUNE/dunesim/pull/84
 - https://github.com/DUNE/dunecore/pull/133

This PR either adds or reconfigures the fcl workflow for gen,g4,detsim,reco1,reco2 for FD1-HD, including running wirecell/hdra for wire signal simulation and signal processing.

This PR also disables the pmtrack workflows as it was failing during testing.  I believe that issue was fixed, but pmtrack is no longer maintained and we have planned on migrating away from it for awhile.  Transitioning to the full 10kt serves as a good point to make that transition.