### PR TITLE
change default channel map for PDHD to the visible wires from the electronics map

### DIFF
--- a/fcl/evd/evd_protoDUNE_data.fcl
+++ b/fcl/evd/evd_protoDUNE_data.fcl
@@ -8,3 +8,4 @@ services.RawDrawingOptions.MinimumSignal: 5.0
 services.RecoDrawingOptions.WireModuleLabels: ["caldata", "digitwire", "wclsdatasp:gauss", "caldata:dataprep"]
 services.ChannelStatusService: @local::pdsp_channel_status
 services.DetectorPropertiesService: @local::protodunesp_detproperties
+services.DetectorPropertiesService.GetReadOutWindowSizefromSamweb: false

--- a/fcl/protodunehd/reco/standard_reco_protodunehd_keepup.fcl
+++ b/fcl/protodunehd/reco/standard_reco_protodunehd_keepup.fcl
@@ -69,7 +69,7 @@ services:
 
   PD2HDChannelMapService:
    {
-     FileName: "PD2HDChannelMap_WIBEth_electronics_v1.txt"
+     FileName: "PD2HDChannelMap_WIBEth_visiblewires_v1.txt"
    }
 }
 


### PR DESCRIPTION
See 

https://github.com/DUNE/duneprototypes/pull/78

for a description of the change in the default channel map from the "electronics" version to the "visiblewires" version.