### PR TITLE
Fix for recording EM shower children in specific SN fcl

### DIFF
--- a/fcl/dunefd/g4/supernova_g4_keepemchildren_dune10kt_1x2x2.fcl
+++ b/fcl/dunefd/g4/supernova_g4_keepemchildren_dune10kt_1x2x2.fcl
@@ -1,6 +1,4 @@
-#include "supernova_g4_keepemchildren_dune10kt_1x2x6.fcl"
+#include "supernova_g4_dune10kt_1x2x2.fcl"
 
-services: {
-    @table::services
-    @table::dunefd_1x2x2_simulation_services
-}
+services.LArG4Parameters.KeepEMShowerDaughters: true
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/fcl/dunefd/g4/supernova_g4_keepemchildren_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/supernova_g4_keepemchildren_dune10kt_1x2x6.fcl
@@ -1,4 +1,4 @@
 #include "supernova_g4_dune10kt_1x2x6.fcl"
 
-services.LArG4Parameters.keepEMShowerDaughters: true
+services.LArG4Parameters.KeepEMShowerDaughters: true
 services.ParticleListAction.keepEMShowerDaughters: true

--- a/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
+++ b/fcl/dunefdvd/reco/workflow_reco_dunevd10kt.fcl
@@ -17,6 +17,7 @@
 #include "PerPlaneCluster.fcl"
 #include "SolarCluster.fcl"
 #include "SolarOpFlash.fcl"
+#include "OpFlashFinderVerticalDrift.fcl"
 #include "angularreco.fcl"
 #include "imagepatternalgs.fcl"
 
@@ -54,9 +55,9 @@ dunefd_vertdrift_producers:
    ophitArOnly:     @local::dunefdvd_ophit
    ophitXeOnly:     @local::dunefdvd_ophit
    ophit10ppm:      @local::dunefdvd_ophit
-   opflashArOnly:   @local::dunefd_opflash
-   opflashXeOnly:   @local::dunefd_opflash
-   opflash10ppm:    @local::dunefd_opflash
+   opflashArOnly:   @local::dunefdvd_opflash
+   opflashXeOnly:   @local::dunefdvd_opflash
+   opflash10ppm:    @local::dunefdvd_opflash
    
    # LE Reco
    # Clusters for LE events


### PR DESCRIPTION
A typo in the supernova fhicls that are supposed to keep the information on EM shower daughters (instead of having their tracks are registered as -1*Parent_ID and their Edeps assigned to their parents) is corrected and the proper syntax for the 1x2x2 fhicl is added.