### PR TITLE
Updates to semi-analytical light simulation: optical path tool

### DIFF
--- a/fcl/dunefd/g4/standard_g4_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/standard_g4_dune10kt_1x2x6.fcl
@@ -4,3 +4,6 @@ services: {
     @table::services
     @table::dunefd_1x2x6_simulation_services
 }
+
+# swap to 1x2x6 pdfastsim configuration
+physics.producers.PDFastSim: @local::dunefd_1x2x6_pdfastsim


### PR DESCRIPTION
Uses DUNE-HD 1x2x6 specific configuration of semi-analytical model. Now split from DUNE-HD 10kt version (default).

Corresponds with PRs: https://github.com/DUNE/duneopdet/pull/104 & https://github.com/LArSoft/larsim/pull/157