### PR TITLE
feat: new fhicls for MUSUN generator in 1x8x6 & 1x8x14 VD geometries for µ generation in rock volume

### DIFF
--- a/fcl/dunefdvd/gen/cosmic/prodMUSUN_dunevd10kt_1x8x14.fcl
+++ b/fcl/dunefdvd/gen/cosmic/prodMUSUN_dunevd10kt_1x8x14.fcl
@@ -1,4 +1,4 @@
-#include "services_dunefd_vertdrift_1x8x6.fcl"
+#include "services_dunefd_vertdrift_1x8x14.fcl"
 #include "MUSUN.fcl"
 
 process_name: MUSUNGen
@@ -12,7 +12,7 @@ services:
    RandomNumberGenerator: {} #ART native random number generator
    FileCatalogMetadata:  @local::art_file_catalog_mc
 
-   @table::dunefdvd_1x8x6_3view_30deg_simulation_services
+   @table::dunefdvd_1x8x14_3view_30deg_simulation_services
 }
 
 #Start each new event with an empty event.
@@ -74,7 +74,7 @@ physics.producers.generator.Ymax:     1405.
 physics.producers.generator.Xmin:    -1534.
 physics.producers.generator.Xmax:     1534.
 physics.producers.generator.Zmin:     -887.
-physics.producers.generator.Zmax:     1784.
+physics.producers.generator.Zmax:     2979.
 
 # Rotate VD around Z by 90 deg: y becomes -x and x becomes y
 physics.producers.generator.DetRotX:               0.         # rotation around X axis, clockwise


### PR DESCRIPTION
This pull request introduces configuration changes to support cosmic ray simulations for DUNE vertical drift detectors in both reduced geometries: `1x8x6` and `1x8x14`. These fhicls will be used for cosmic ray muon studies as external background for nucleon decay searches, as well as for atmospheric neutrinos.

### Configuration for `1x8x14` geometry:
* Added a new FCL file (`prodMUSUN_dunevd10kt_1x8x14.fcl`) to configure cosmic ray simulation for the `1x8x14` geometry. This geometry is recommended for light studies, to account for the xenon doping.

### Updates to `1x8x6` geometry:
* Modified the coordinate ranges (`Xmin`, `Xmax`, `Ymin`, `Ymax`, `Zmin`, `Zmax`) in `prodMUSUN_dunevd10kt_1x8x6.fcl` to make up the adequate rock volume dimensions of the `1x8x6` geometry. At present, the generation volume boundaries correspond to the active volume dimensions for calibration purposes.

The rock volume boundaries were derived from the `detector enclosure` volume defined in the `gdml` files — [https://github.com/DUNE/dunecore/blob/5aa7718660e58cfd58a52b3f4f82c87da0e56057/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x6_nowires.gdml#L746-L749](url) & [https://github.com/DUNE/dunecore/blob/5aa7718660e58cfd58a52b3f4f82c87da0e56057/dunecore/Geometry/gdml/dunevd10kt_3view_30deg_v6_refactored_1x8x14_nowires.gdml#L746-L749](url). This was carried out as follows:

* Considering its position respecting the world volume.
* Adding 5 meters of rock on each side of the detector enclosure, except at the top. In that case, 7 meters of rock were accounted for.