### PR TITLE
Adding an angle reco method in cafmaker fcl

### DIFF
--- a/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl
+++ b/fcl/dunefd/caf/cafmaker_dune10kt_1x2x6_runreco-nuenergy.fcl
@@ -16,6 +16,7 @@ dunefd_hd_producers:
     anglereconumu:      @local::dunefd_nuangularreco_pandora_numu
     anglereconuepfps:   @local::dunefd_nuangularreco_pandora_nue_allpfps
     anglereconumupfps:  @local::dunefd_nuangularreco_pandora_numu_allpfps
+    anglerecohits:      @local::dunefd_nuangularreco_pandora_hits
 }
 
 dunefd_hd_ereco:
@@ -33,7 +34,8 @@ dunefd_hd_anglereco:
     anglereconue,
     anglereconumu,
     anglereconuepfps,
-    anglereconumupfps
+    anglereconumupfps,
+    anglerecohits
 ]
 
 physics.producers: {


### PR DESCRIPTION
Minor PR to add an angle reco method in the cafmaker fcl file that also re-runs the ereco and direction reco algorithms.