### PR TITLE
Revert "Revert "Updates to semi-analytical light simulation: optical path tool""

### DIFF
--- a/fcl/dunefd/g4/standard_g4_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/g4/standard_g4_dune10kt_1x2x6.fcl
@@ -4,3 +4,6 @@ services: {
     @table::services
     @table::dunefd_1x2x6_simulation_services
 }
+
+# swap to 1x2x6 pdfastsim configuration
+physics.producers.PDFastSim: @local::dunefd_1x2x6_pdfastsim


### PR DESCRIPTION
Reverts DUNE/dunesw#191 that reverts https://github.com/DUNE/dunesw/pull/186 merged before corresponding larsoft PR. 

Do not merge until https://github.com/LArSoft/larsim/pull/157. 