### PR TITLE
Changing message service to prod for cafmaker

### DIFF
--- a/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/caf/standard_cafmaker_dune10kt_1x2x6.fcl
@@ -10,6 +10,7 @@ services:
   @table::dunefd_1x2x6_reco_services
   # Load the service that manages root files for histograms where the CAF info will be saved.
   TFileService: { fileName: "caf.root" }
+  message: @local::dune_message_services_prod
 }
 
 source:

--- a/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
+++ b/fcl/dunefdvd/caf/standard_cafmaker_dunevd10kt_1x8x6_3view_30deg.fcl
@@ -11,6 +11,7 @@ services:
   @table::dunefdvd_1x8x6_3view_30deg_reco_services
   # Load the service that manages root files for histograms where the CAF info will be saved.
   TFileService: { fileName: "caf.root" }
+  message: @local::dune_message_services_prod
 }
 
 source:


### PR DESCRIPTION
Changing the default messaging service for the CAFMaker fcl to `prod` to ease up the production with smaller output log files.