### PR TITLE
Add gen FCL for atmospheric neutrinos + radiological backgrounds (DUNE FD HD 1x2x6)

### DIFF
--- a/fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_radiological_decay0_dune10kt_1x2x6.fcl
+++ b/fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_radiological_decay0_dune10kt_1x2x6.fcl
@@ -1,0 +1,14 @@
+#include "workflow_radiological_decay0_dune10kt.fcl"
+
+#include "prodgenie_atmnu_max_weighted_randompolicy_dune10kt_1x2x6.fcl"
+
+physics:
+{
+  @table::physics
+  producers:
+  {
+    @table::physics.producers
+    @table::dunefd_horizdrift_1x2x6_producers
+  }
+  simulate: [ rns, generator, @sequence::dunefd_hd_backgrounds_1x2x6_lowBgAPA ]      
+}


### PR DESCRIPTION
## Summary

Add a new generation FHiCL configuration to simulate atmospheric neutrinos overlaid with the full set of DUNE FD HD `1x2x6` radiological backgrounds.

**New file:** `fcl/dunefd/gen/atm/prodgenie_atmnu_max_weighted_randompolicy_radiological_decay0_dune10kt_1x2x6.fcl`

## Physics content

| Component | Configuration |
|-----------|--------------|
| Neutrino generator | GENIE Honda atmospheric flux, max flux, importance-weighted, random seed policy |
| Radiological model | Decay0, full `1x2x6` set with attenuated lowBgAPA external backgrounds |
| Geometry | DUNE FD HD 1×2×6 |

## Design

The FCL builds on two existing configurations:
- `prodgenie_atmnu_max_weighted_randompolicy_dune10kt_1x2x6.fcl` — atmospheric neutrino generator
- `workflow_radiological_decay0_dune10kt.fcl` — radiological producer definitions

It extends `physics.producers` with `@table::dunefd_horizdrift_1x2x6_producers` (all radiological producers for the 1x2x6 geometry) and runs the simulate path as:
```
simulate: [ rns, generator, @sequence::dunefd_hd_backgrounds_1x2x6_lowBgAPA ]
```

## Testing

- FHiCL validated with `fhicl-dump` against `dunesw v10_20_09d01 (e26:prof)` — parses without errors.