### PR TITLE
Spack mpd build and test: Updated test environment variable definitions. 

### DIFF
--- a/test/ArtServices/CMakeLists.txt
+++ b/test/ArtServices/CMakeLists.txt
@@ -1,7 +1,7 @@
 cet_transitive_paths(FHICL_DIR BINARY IN_TREE)
-cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR} ${dunesim_BINARY_DIR}/fcl ${duneopdet_BINARY_DIR}/fcl ${dunecalib_BINARY_DIR}/fcl ${duneprototypes_BINARY_DIR}/fcl ${dunedataprep_BINARY_DIR}/fcl)
+cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR} ${PROJECT_BINARY_DIR}/../dunesim/fcl ${PROJECT_BINARY_DIR}/../duneopdet/fcl ${PROJECT_BINARY_DIR}/../dunecalib/fcl ${PROJECT_BINARY_DIR}/../duneprototypes/fcl ${PROJECT_BINARY_DIR}/../dunedataprep/fcl)
 cet_transitive_paths(LIBRARY_DIR BINARY IN_TREE)
-cet_test_env_prepend(CET_PLUGIN_PATH ${TRANSITIVE_PATHS_WITH_LIBRARY_DIR})
+cet_test_env_prepend(CET_PLUGIN_PATH ${TRANSITIVE_PATHS_WITH_LIBRARY_DIR} ${PROJECT_BINARY_DIR}/../dunesim/lib)
 cet_transitive_paths(GDML_DIR BINARY IN_TREE)
 cet_test_env_prepend(FW_SEARCH_PATH ${TRANSITIVE_PATHS_WITH_GDML_DIR})
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,11 +3,11 @@
 include(CetTest)
 
 cet_transitive_paths(FHICL_DIR BINARY IN_TREE)
-cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR} ${PACKAGE_BINARY_PATH}/fcl ${dunesim_BINARY_DIR}/fcl ${duneopdet_BINARY_DIR}/fcl ${dunecalib_BINARY_DIR}/fcl ${duneprototypes_BINARY_DIR}/fcl ${dunedataprep_BINARY_DIR}/fcl)
+cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR} ${PACKAGE_BINARY_PATH}/fcl ${PROJECT_BINARY_DIR}/../dunesim/fcl ${PROJECT_BINARY_DIR}/../duneopdet/fcl ${PROJECT_BINARY_DIR}/../dunecalib/fcl ${PROJECT_BINARY_DIR}/../duneprototypes/fcl ${PROJECT_BINARY_DIR}/../dunedataprep/fcl)
 cet_transitive_paths(LIBRARY_DIR BINARY IN_TREE)
-cet_test_env_prepend(CET_PLUGIN_PATH ${TRANSITIVE_PATHS_WITH_LIBRARY_DIR})
+cet_test_env_prepend(CET_PLUGIN_PATH ${TRANSITIVE_PATHS_WITH_LIBRARY_DIR} ${PROJECT_BINARY_DIR}/../duneopdet/lib)
 cet_transitive_paths(GDML_DIR BINARY IN_TREE)
-cet_test_env_prepend(FW_SEARCH_PATH ${TRANSITIVE_PATHS_WITH_GDML_DIR} ${dunecore_BINARY_DIR}/gdml)
+cet_test_env_prepend(FW_SEARCH_PATH ${TRANSITIVE_PATHS_WITH_GDML_DIR} ${PROJECT_BINARY_DIR}/../dunecore/gdml)
 
 cet_enable_asserts()
 

--- a/test/EventGenerator/CMakeLists.txt
+++ b/test/EventGenerator/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 # simple examples using prodsingle
 cet_transitive_paths(FHICL_DIR BINARY IN_TREE)
-cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR} ${PACKAGE_BINARY_DIR}/fcl ${dunecalib_BINARY_DIR}/fcl ${dunesim_BINARY_DIR}/fcl ${duneopdet_BINARY_DIR}/fcl ${dunedataprep_BINARY_DIR}/fcl ${duneprototypes_BINARY_DIR}/fcl)
+cet_test_env_prepend(FHICL_FILE_PATH "." ${TRANSITIVE_PATHS_WITH_FHICL_DIR} ${PACKAGE_BINARY_DIR}/fcl ${PROJECT_BINARY_DIR}/../dunecalib/fcl ${PROJECT_BINARY_DIR}/../dunesim/fcl ${PROJECT_BINARY_DIR}/../duneopdet/fcl ${PROJECT_BINARY_DIR}/../dunedataprep_/fcl ${PROJECT_BINARY_DIR}/../duneprototypes/fcl)
 cet_transitive_paths(LIBRARY_DIR BINARY IN_TREE)
 cet_test_env_prepend(CET_PLUGIN_PATH ${TRANSITIVE_PATHS_WITH_LIBRARY_DIR})
 


### PR DESCRIPTION
Use CMake variables that exist to define test environment vars 