### PR TITLE
[spack mpd] Explicitly unload services to avoid segfaults

### DIFF
--- a/test/ArtServices/test_DetectorClocksService.cxx
+++ b/test/ArtServices/test_DetectorClocksService.cxx
@@ -42,6 +42,10 @@ int test_DetectorClocksService(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  // Destroy the art services (and thus close TFileService, which writes
+  // a ROOT file in its destructor) while ROOT/Cling is still alive.
+  // Otherwise the services are only destroyed at program exit, when the
+  // interpreter state they rely on may already be gone, causing a crash.
   ArtServiceHelper::unload_services();
   return 0;
 }

--- a/test/ArtServices/test_DetectorClocksService.cxx
+++ b/test/ArtServices/test_DetectorClocksService.cxx
@@ -42,6 +42,7 @@ int test_DetectorClocksService(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  ArtServiceHelper::unload_services();
   return 0;
 }
 

--- a/test/ArtServices/test_DetectorProperties.cxx
+++ b/test/ArtServices/test_DetectorProperties.cxx
@@ -42,6 +42,10 @@ int test_DetectorPropertiesService(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  // Destroy the art services (and thus close TFileService, which writes
+  // a ROOT file in its destructor) while ROOT/Cling is still alive.
+  // Otherwise the services are only destroyed at program exit, when the
+  // interpreter state they rely on may already be gone, causing a crash.
   ArtServiceHelper::unload_services();
   return 0;
 }

--- a/test/ArtServices/test_DetectorProperties.cxx
+++ b/test/ArtServices/test_DetectorProperties.cxx
@@ -42,6 +42,7 @@ int test_DetectorPropertiesService(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  ArtServiceHelper::unload_services();
   return 0;
 }
 

--- a/test/ArtServices/test_Geometry.cxx
+++ b/test/ArtServices/test_Geometry.cxx
@@ -52,6 +52,7 @@ int test_Geometry(string gname) {
   cout << myname << "Geometry name: " << pgeo->DetectorName() << endl;
 
   cout << myname << line << endl;
+  ArtServiceHelper::unload_services();
   return 0;
 }
 

--- a/test/ArtServices/test_Geometry.cxx
+++ b/test/ArtServices/test_Geometry.cxx
@@ -52,6 +52,10 @@ int test_Geometry(string gname) {
   cout << myname << "Geometry name: " << pgeo->DetectorName() << endl;
 
   cout << myname << line << endl;
+  // Destroy the art services (and thus close TFileService, which writes
+  // a ROOT file in its destructor) while ROOT/Cling is still alive.
+  // Otherwise the services are only destroyed at program exit, when the
+  // interpreter state they rely on may already be gone, causing a crash.
   ArtServiceHelper::unload_services();
   return 0;
 }

--- a/test/ArtServices/test_LArProperties.cxx
+++ b/test/ArtServices/test_LArProperties.cxx
@@ -43,6 +43,7 @@ int test_LArPropertiesStandard(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  ArtServiceHelper::unload_services();
   return 0;
 }
 

--- a/test/ArtServices/test_LArProperties.cxx
+++ b/test/ArtServices/test_LArProperties.cxx
@@ -43,6 +43,10 @@ int test_LArPropertiesStandard(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  // Destroy the art services (and thus close TFileService, which writes
+  // a ROOT file in its destructor) while ROOT/Cling is still alive.
+  // Otherwise the services are only destroyed at program exit, when the
+  // interpreter state they rely on may already be gone, causing a crash.
   ArtServiceHelper::unload_services();
   return 0;
 }

--- a/test/ArtServices/test_LArSeedService.cxx
+++ b/test/ArtServices/test_LArSeedService.cxx
@@ -46,6 +46,7 @@ int test_LArSeedService(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  ArtServiceHelper::unload_services();
   return 0;
 }
 

--- a/test/ArtServices/test_LArSeedService.cxx
+++ b/test/ArtServices/test_LArSeedService.cxx
@@ -46,6 +46,10 @@ int test_LArSeedService(string gname) {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  // Destroy the art services (and thus close TFileService, which writes
+  // a ROOT file in its destructor) while ROOT/Cling is still alive.
+  // Otherwise the services are only destroyed at program exit, when the
+  // interpreter state they rely on may already be gone, causing a crash.
   ArtServiceHelper::unload_services();
   return 0;
 }

--- a/test/ArtServices/test_SignalShapingServiceDUNE.cxx
+++ b/test/ArtServices/test_SignalShapingServiceDUNE.cxx
@@ -107,6 +107,7 @@ int test_SignalShapingServiceDUNE() {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  ArtServiceHelper::unload_services();
   return 0;
 }
 

--- a/test/ArtServices/test_SignalShapingServiceDUNE.cxx
+++ b/test/ArtServices/test_SignalShapingServiceDUNE.cxx
@@ -107,6 +107,10 @@ int test_SignalShapingServiceDUNE() {
 
   cout << myname << line << endl;
   cout << "Done." << endl;
+  // Destroy the art services (and thus close TFileService, which writes
+  // a ROOT file in its destructor) while ROOT/Cling is still alive.
+  // Otherwise the services are only destroyed at program exit, when the
+  // interpreter state they rely on may already be gone, causing a crash.
   ArtServiceHelper::unload_services();
   return 0;
 }


### PR DESCRIPTION
Add ArtServiceHelper::unload_services() before return to ensure proper cleanup of pointers. Under spack mpd test the return segfaults.
Depends on https://github.com/DUNE/dunecore/pull/183